### PR TITLE
Persist logs to file for easier debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.qodo
 /.venv
+*.log

--- a/PoGo_rarity.py
+++ b/PoGo_rarity.py
@@ -20,8 +20,15 @@ import random
 import argparse
 
 # Configure logging
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+LOG_FILE = Path(__file__).with_name("pogo_debug.log")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(),
+    ],
+)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- write logging output to `pogo_debug.log` via FileHandler
- ignore generated log files in version control

## Testing
- `python PoGo_rarity.py --limit 1`


------
https://chatgpt.com/codex/tasks/task_e_68bf874e7a38832885175104feb3bcf8