### PR TITLE
Handle regional forms and improve observability

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/fixtures/pokemondb_bulbasaur.html
+++ b/tests/fixtures/pokemondb_bulbasaur.html
@@ -1,0 +1,942 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Bulbasaur Pokédex: stats, moves, evolution &amp; locations | Pokémon Database</title>
+
+	<link rel="preconnect" href="https://img.pokemondb.net">
+	<link rel="preconnect" href="https://s.pokemondb.net">
+	<link rel="preload" href="/static/fonts/fira-sans-v17-latin-400.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/static/fonts/fira-sans-v17-latin-400i.woff2" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="/static/fonts/fira-sans-v17-latin-600.woff2" as="font" type="font/woff2" crossorigin>
+		<link rel="stylesheet" href="/static/css/pokemondb-9ad4b87c02.css">
+	<link rel="stylesheet" href="/static/css/type-chart-76998cbd3d.css">
+	<link rel="stylesheet" href="/static/css/evolution-6ccf58cfbe.css">
+	<style>.cell-barchart{width:100%;min-width:150px}.barchart-bar{height:.75rem;border-radius:4px;background-color:#a3a3a3;border:1px solid #737373;border-color:rgba(0,0,0,.15)}.barchart-rank-1{background-color:#f34444}.barchart-rank-2{background-color:#ff7f0f}.barchart-rank-3{background-color:#ffdd57}.barchart-rank-4{background-color:#a0e515}.barchart-rank-5{background-color:#23cd5e}.barchart-rank-6{background-color:#00c2b8}.etymology>dd{margin-bottom:0}.sprites-table th,.sprites-table td{border-width:1px;text-align:center}.sprites-table tr:hover{background-color:transparent}.sprites-history-table th,.sprites-history-table td{padding:.75rem 1.25rem}.cell-sprite-games{width:135px;padding-top:1rem;padding-bottom:1rem;vertical-align:top !important}.cell-sprite-list{min-width:250px}.sprites-table-card{display:inline-block;vertical-align:top;max-width:150px}.sprite-share-link{display:inline-block;border-radius:4px;padding:.5rem;transition:background-color .3s ease-in-out}.sprite-share-link:hover{background-color:#e5fbec}.sprite-share-link.sprite-anim{min-width:96px;min-height:96px;line-height:96px}.modal-content .input-text{width:100%;padding:.25rem;font-family:"Consolas","Ubuntu Mono","Menlo","Bitstream Vera Sans Mono","Courier New",monospace;font-size:.75rem}</style>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta property="og:description" name="description" content="Pokédex entry for #1 Bulbasaur containing stats, moves learned, evolution chain, location and more!">
+	<link rel="canonical" href="https://pokemondb.net/pokedex/bulbasaur">
+	<meta property="og:url" content="https://pokemondb.net/pokedex/bulbasaur">
+	<link rel="contents" href="https://pokemondb.net/pokedex/all">
+
+	<meta property="og:image" content="https://img.pokemondb.net/artwork/large/bulbasaur.jpg">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="robots" content="max-image-preview:large">
+	<meta property="og:title" content="Bulbasaur Pokédex: stats, moves, evolution &amp; locations">
+	
+	<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+	<link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-precomposed.png">
+	<link rel="alternate" type="application/rss+xml" href="https://pokemondb.net/news/feed" title="The Pokémon Database newsfeed">
+
+	<script>var localDbVersions = 250908;</script>
+			<script defer src="/static/js/global-b07c1b928a.js"></script>
+		<script defer src="/static/js/views/lightbox-386c94c759.js"></script>
+<script defer src="/static/js/views/sprites-bd00b2e39e.js"></script>
+		<script defer src="data:text/javascript;base64,KGZ1bmN0aW9uKCkgewoJLy8gbXVzdCBkbyBuZXN0ZWQgdGFicyBmcm9tIHRoZSBpbnNpZGUgb3V0Cgljb25zdCB0YWJPcmRlciA9IFsnLnRhYnNldC10eXBlZGVmY29sJywgJy50YWJzZXQtYmFzaWNzJywgJy50YWJzZXQtbW92ZXMtZ2FtZS1mb3JtJywgJy50YWJzZXQtbW92ZXMtZ2FtZSddOwoKCWZvciAobGV0IHNlbGVjdG9yIG9mIHRhYk9yZGVyKSB7CgkJZm9yIChsZXQgdGFiU2V0IG9mIGVsUVNBKHNlbGVjdG9yKSkgewoJCQluZXcgU1YuVGFicyh0YWJTZXQpOwoJCX0KCX0KfSkoKTsKCihmdW5jdGlvbiAoKSB7Cgljb25zdCB0YWJsZXMgPSBlbENsYXNzKCdkYXRhLXRhYmxlJyk7CgoJZm9yIChsZXQgdGFibGUgb2YgdGFibGVzKSB7CgkJbGV0IHNvcnRhYmxlID0gbmV3IFNWLlNvcnRhYmxlKHRhYmxlLCB7CgkJCWluaXRpYWxTb3J0OiAwLAoJCX0pOwoKCQlvbkV2ZW50KHRhYmxlLCAnc3Yuc29ydGFibGUuYmVmb3JlJywgZnVuY3Rpb24oZXYpIHsKCQkJLy8gbW92ZSBibGFua3MgdG8gYm90dG9tCgkJCXNvcnRhYmxlU2V0QmxhbmtWYWx1ZXMoc29ydGFibGUsIHRhYmxlLCBldi5kZXRhaWwpOwoJCX0pOwoJfQp9KSgpOwoK"></script>
+
+			<script>
+(function(){
+	var bsa_optimize=document.createElement('script');
+	bsa_optimize.defer=true;
+	bsa_optimize.src='https://cdn4.buysellads.net/pub/pokemondb.js?'+(new Date()-new Date()%600000);
+	(document.getElementsByTagName('head')[0]||document.getElementsByTagName('body')[0]).appendChild(bsa_optimize);
+})();
+</script>		<noscript>
+		<style>.main-menu-item:hover > .main-menu-sub { visibility: visible; opacity: 1; }</style>
+	</noscript>
+</head>
+
+<body>
+<a class="sr-only" href="#main">Skip to main content</a>
+
+<header class="main-header">
+	<div class="grid-container">
+		<a href="/" class="header-logo">
+	<picture>
+		<source type="image/avif" media="(min-width: 900px)" width="1140" height="100"
+			srcset="https://img.pokemondb.net/design/avif/header-lg.avif">
+		<source type="image/avif" media="(min-width: 620px)" width="807" height="100"
+			srcset="https://img.pokemondb.net/design/avif/header-md.avif, https://img.pokemondb.net/design/avif/header-md-2x.avif 2x">
+		<source type="image/avif" width="367" height="100"
+			srcset="https://img.pokemondb.net/design/avif/header-sm.avif, https://img.pokemondb.net/design/avif/header-sm-2x.avif 2x">
+		<source type="image/png" media="(min-width: 900px)" width="1140" height="100"
+			srcset="https://img.pokemondb.net/design/header-lg.png">
+		<source type="image/png" media="(min-width: 620px)" width="807" height="100"
+			srcset="https://img.pokemondb.net/design/header-md.png, https://img.pokemondb.net/design/header-md-2x.png 2x">
+		<img src="https://img.pokemondb.net/design/header-sm.png" alt="Pokemon Database logo, with Scizor"
+			srcset="https://img.pokemondb.net/design/header-sm-2x.png 2x" fetchpriority="high">
+	</picture>
+</a>
+	</div>
+</header>
+
+
+<nav class="main-menu grid-container">
+	<ul class="main-menu-list">
+			<li class="main-menu-item">
+			<a class="main-menu-heading" href="/sitemap">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="main-menu-icon img-fixed" width="24" height="24" aria-label="Pokeball icon" role="img"><g fill="#a3a3a3"><path d="M229.7 36.8A220.9 220.9 0 0 0 37.5 224.9l-.4 4.3h106.5l1.4-4.7a116.3 116.3 0 0 1 73-77.5 114.7 114.7 0 0 1 149 79l.9 3.2H475l-1.7-10.1A220 220 0 0 0 281 36.7c-12-1.4-39.3-1.4-51.2 0z"/><path d="M239.7 185a74 74 0 0 0-49.7 40.3 73 73 0 0 0 15.4 82.3 72.1 72.1 0 0 0 101.9-1.2 68.8 68.8 0 0 0 20.6-50.7 69.1 69.1 0 0 0-21-51.2 73.3 73.3 0 0 0-33-19c-7.6-2.1-26.4-2.3-34.2-.5z"/><path d="M37.5 286.3a220.5 220.5 0 0 0 436 4.5l1.5-8.9H367.9l-1 3.2a130 130 0 0 1-17.7 37.6 144 144 0 0 1-26.9 26.8 142 142 0 0 1-30.7 15.4 96.3 96.3 0 0 1-35.8 5.3 90 90 0 0 1-22.5-1.7 114 114 0 0 1-58.6-31.7 110.1 110.1 0 0 1-28.3-46l-2.9-8.9H37l.6 4.4h-.1z"/></g></svg>				<span class="main-menu-title">Data</span>
+				<span class="main-menu-title-long">Pokémon data</span>
+			</a>
+			<ul class="main-menu-sub">
+												<li><a href="/pokedex">Pokédex</a></li>
+																<li><a href="/move">Moves</a></li>
+																<li><a href="/type">Type chart</a></li>
+																<li><a href="/ability">Abilities</a></li>
+																<li><a href="/item">Items</a></li>
+																<li><a href="/evolution">Evolution chains</a></li>
+																<li><a href="/location">Pokémon locations</a></li>
+																<li><a href="/sprites">Sprite gallery</a></li>
+																<li class="main-menu-hr-title">Quick links</li>
+																<li><a href="/pokedex/national">National Pokédex</a></li>
+																<li><a href="/pokedex/all">Pokémon list with stats</a></li>
+																<li><a href="/pokedex/game/legends-arceus">Legends: Arceus Pokédex</a></li>
+																<li><a href="/pokedex/game/scarlet-violet">Scarlet &amp; Violet Pokédex</a></li>
+										</ul>
+		</li>
+			<li class="main-menu-item">
+			<a class="main-menu-heading" href="/sitemap">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="main-menu-icon img-fixed" width="24" height="24" aria-label="Mechanics icon" role="img"><path fill="#a3a3a3" d="M479.5 297.5v-82l-50.3-8.4a156.5 156.5 0 0 0-16-38.3l30-40.8-57.7-58.8-42 29c-12-6.5-25-12.2-38.2-15.9L297 33h-82l-8.3 50.3a163 163 0 0 0-38.3 16l-41-29.1L68.8 128l29.9 41A184 184 0 0 0 82.8 208l-50.3 7.4v82l50.3 8.3a163 163 0 0 0 16 38.3l-30 41.7 57.6 57.6 42-29.7a184 184 0 0 0 39 15.8l8.4 49.5h82l8.3-50.4c13.1-3.7 26-9.3 38.3-15.8l41.9 29.8 57.6-57.8-29.7-42c6.4-12 12-24 15.8-38.1l49.3-7.4.2.2zM255.8 342c-47.5 0-85.7-38.3-85.7-85.7s39.1-85.7 85.7-85.7 85.8 38.3 85.8 85.7-38.3 85.7-85.8 85.7z"/></svg>				<span class="main-menu-title">Mechanics</span>
+				<span class="main-menu-title-long">Game mechanics</span>
+			</a>
+			<ul class="main-menu-sub">
+												<li><a href="/mechanics/breeding">Breeding &amp; egg groups</a></li>
+																<li><a href="/mechanics/move-tutors">Move Tutors</a></li>
+																<li><a href="/type/dual">Dual type chart</a></li>
+																<li><a href="/ev">Effort Values (EVs)</a></li>
+																<li><a href="/mechanics/natures">Natures</a></li>
+																<li><a href="/mechanics/hidden">IVs/Personality</a></li>
+																<li class="main-menu-hr-title">Useful tools</li>
+																<li><a href="/tools/moveset-search">Moveset searcher</a></li>
+																<li><a href="/tools/type-coverage">Type coverage checker</a></li>
+																<li><a href="/tools/text-list">Text list generator</a></li>
+										</ul>
+		</li>
+			<li class="main-menu-item">
+			<a class="main-menu-heading" href="/sitemap">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="main-menu-icon img-fixed" width="24" height="24" aria-label="Game controller icon" role="img"><path fill="#a3a3a3" fill-rule="evenodd" d="M117.4 121.9c-104.8 14.6-152 142.6-82.2 222.9 48 55 131.9 62.7 187.2 17l4.6-3.8H285l4.6 3.7c55.3 45.8 139.3 38.2 187.2-17 70.2-80.6 22.4-208.6-83.1-222.9-14.8-2-261.9-2-276.2 0m42.8 52.8c2.2 2.2 2.2 2.7 2.5 29.4l.3 27.2h53.5l2.4 2.5c3.8 3.8 3.8 40.8 0 44.6l-2.4 2.4H163l-.3 27.2c-.4 35 2.2 31.7-25 31.7-27.3 0-24.7 3.3-25-31.7l-.4-27.2H59l-2.4-2.4c-3.9-3.8-3.9-40.8 0-44.6l2.4-2.5h53.4l.3-27c.4-35-1.8-32.4 26.3-32 18.3.1 19 .2 21.3 2.4m259.3 16.5a33.7 33.7 0 0 1 19.5 42.5 33.2 33.2 0 0 1-59 5.8c-16.4-26.6 9.7-58.4 39.5-48.3M352 259a33 33 0 0 1 3.7 60 32.7 32.7 0 0 1-48-27.3A32.9 32.9 0 0 1 352 259"/></svg>				<span class="main-menu-title">Games</span>
+				<span class="main-menu-title-long">Pokémon games</span>
+			</a>
+			<ul class="main-menu-sub">
+												<li><a href="/legends-z-a">Legends: Z-A</a></li>
+																<li><a href="/scarlet-violet">Scarlet &amp; Violet</a></li>
+																<li><a href="/go">Pokémon GO</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/legends-arceus">Legends: Arceus</a></li>
+																<li><a href="/brilliant-diamond-shining-pearl">Brilliant Diamond &amp; Shining Pearl</a></li>
+																<li><a href="/sword-shield">Sword &amp; Shield</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/lets-go-pikachu-eevee">Let&#039;s Go Pikachu &amp; Let&#039;s Go Eevee</a></li>
+																<li><a href="/ultra-sun-ultra-moon">Ultra Sun &amp; Ultra Moon</a></li>
+																<li><a href="/sun-moon">Sun &amp; Moon</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/omega-ruby-alpha-sapphire">Omega Ruby &amp; Alpha Sapphire</a></li>
+																<li><a href="/x-y">X &amp; Y</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/black-white-2">Black 2 &amp; White 2</a></li>
+																<li><a href="/black-white">Black &amp; White</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/heartgold-soulsilver">HeartGold &amp; SoulSilver</a></li>
+																<li><a href="/platinum">Platinum</a></li>
+																<li><a href="/diamond-pearl">Diamond &amp; Pearl</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/emerald">Emerald</a></li>
+																<li><a href="/firered-leafgreen">FireRed &amp; LeafGreen</a></li>
+																<li><a href="/ruby-sapphire">Ruby &amp; Sapphire</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/crystal">Crystal</a></li>
+																<li><a href="/gold-silver">Gold &amp; Silver</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/yellow">Yellow</a></li>
+																<li><a href="/red-blue">Red &amp; Blue</a></li>
+																<li class="main-menu-hr"></li>
+																<li><a href="/spinoff">Spin-off games</a></li>
+										</ul>
+		</li>
+			<li class="main-menu-item">
+			<a class="main-menu-heading" href="/sitemap">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="main-menu-icon img-fixed" width="24" height="24" aria-label="Chat icon" role="img"><path fill="#a3a3a3" d="M36.5 95v241.5a44.5 44.5 0 0 0 43.9 43.9h58.5v73.1a7.3 7.3 0 0 0 12.8 5l71-78.1h208.9a44.5 44.5 0 0 0 43.9-44V95a44.5 44.5 0 0 0-43.9-43.9H80.4a44.5 44.5 0 0 0-43.9 44zm292.7 117.1a29.3 29.3 0 1 1 58.6 0 29.3 29.3 0 0 1-58.6 0zm-102.5 0a29.3 29.3 0 1 1 58.6 0 29.3 29.3 0 0 1-58.6 0zm-102.4 0a29.3 29.3 0 1 1 58.6 0 29.3 29.3 0 0 1-58.6 0z"/></svg>				<span class="main-menu-title">Other</span>
+				<span class="main-menu-title-long">Community/Other</span>
+			</a>
+			<ul class="main-menu-sub">
+												<li><a href="/pokebase/">Pokémon Q&amp;A</a></li>
+																<li><a href="/pokebase/rmt/">Pokémon Rate My Team</a></li>
+																<li><a href="/pokebase/chat">Chat Room</a></li>
+																<li><a href="/pokebase/meta/">Meta (Suggestion Box)</a></li>
+																<li class="main-menu-hr-title">Other pages</li>
+																<li><a href="/">Pokémon News</a></li>
+																<li><a href="/maps">Maps/Puzzles</a></li>
+																<li><a href="/etymology">Pokémon name origins</a></li>
+																<li><a href="/about">About/Contact us</a></li>
+										</ul>
+		</li>
+			<li class="main-menu-item main-menu-item-search">
+			<form method="get" action="/search" class="sitesearch-form">
+				<label class="sr-only" for="sitesearch">Search</label>
+				<input id="sitesearch" class="input-text sitesearch-input" type="text" name="q" autocomplete="off" placeholder="Search" tabindex="100">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="main-menu-icon img-fixed" width="20" height="20" aria-label="Search" role="img"><path fill="#a3a3a3" d="M495.6 466.4L373.8 339.6a206 206 0 0 0 48.5-132.9C422.3 92.7 329.5 0 215.6 0S8.8 92.7 8.8 206.7s92.8 206.7 206.8 206.7c42.8 0 83.5-12.9 118.4-37.4l122.8 127.7a26.8 26.8 0 0 0 38.1.8 27 27 0 0 0 .7-38.1zm-280-412.5c84.2 0 152.8 68.6 152.8 152.8s-68.6 152.8-152.8 152.8S62.8 291 62.8 206.7 131.3 54 215.6 54z"/></svg>				<div class="sitesearch-results"></div>
+			</form>
+		</li>
+	</ul>
+</nav>
+
+<main id="main" class="main-content grid-container">
+
+<h1>Bulbasaur</h1>
+
+
+<nav class="entity-nav component">
+	<a rel="next" class="entity-nav-next" href="/pokedex/ivysaur">#0002 Ivysaur</a>
+</nav>
+
+<ul class="list-nav panel panel-nav">
+	<li class="list-nav-title">Contents</li>
+	<li><a href="#dex-basics">Info</a></li>
+	<li><a href="#dex-stats">Base stats</a></li>
+	<li><a href="#dex-evolution">Evolution chart</a></li>
+	<li><a href="#dex-flavor">Pokédex entries</a></li>
+	<li><a href="#dex-moves">Moves learned</a></li>
+	<li><a href="#dex-sprites">Sprites</a></li>
+	<li><a href="#dex-locations">Locations</a></li>
+	<li><a href="#dex-lang">Language</a></li>
+</ul>
+
+<p><em>Bulbasaur</em> is a <a href="/type/grass"class="itype grass">Grass</a>/<a href="/type/poison"class="itype poison">Poison</a> type Pokémon introduced in <abbr title="Pokémon Red, Blue &amp; Yellow">Generation 1</abbr>.</p>
+<p><em>Bulbasaur</em> is a small, mainly turquoise amphibian Pokémon with red eyes and a green bulb on its back. It is based on a frog/toad, with the bulb resembling a plant bulb that grows into a flower as it evolves.</p>
+<p><em>Bulbasaur</em> is notable for being the very first Pokémon in the National Pokédex. It is one of the three choices for a <q>starter Pokémon</q> in the original Game Boy games, Pokémon Red &amp; Blue (Red &amp; Green in Japan), along with <a href="/pokedex/charmander">Charmander</a> and <a href="/pokedex/squirtle">Squirtle</a>.</p>
+
+<div id="dex-basics"></div>
+<div class="tabset-basics sv-tabs-wrapper sv-tabs-onetab">
+	<div class="sv-tabs-tab-list">
+			<a class="sv-tabs-tab active" href="#tab-basic-1">Bulbasaur</a>
+		</div>
+
+	<div class="sv-tabs-panel-list">
+			<div class="sv-tabs-panel active" id="tab-basic-1">
+
+			<div class="grid-row">
+				<div class="grid-col span-md-6 span-lg-4 text-center">
+											<p><a rel="lightbox" href="https://img.pokemondb.net/artwork/large/bulbasaur.jpg" data-title="Bulbasaur official artwork"><picture>
+	<source srcset="https://img.pokemondb.net/artwork/avif/bulbasaur.avif" width="360" height="336" type="image/avif">
+	<img src="https://img.pokemondb.net/artwork/bulbasaur.jpg" width="360" height="336" alt="Bulbasaur artwork by Ken Sugimori" fetchpriority="high">
+</picture></a></p>
+																<p class="text-small"><a href="/artwork/bulbasaur">Additional artwork</a></p>
+									</div>
+
+				<div class="grid-col span-md-6 span-lg-4">
+					<h2>Pokédex data</h2>
+					<table class="vitals-table">
+	<tbody>
+	<tr>
+		<th>National &#8470;</th>
+		<td><strong>0001</strong></td>
+	</tr>
+	<tr>
+		<th>Type</th>
+		<td>
+			<a class="type-icon type-grass"  href="/type/grass" >Grass</a>			<a class="type-icon type-poison"  href="/type/poison" >Poison</a>		</td>
+	</tr>
+	<tr>
+		<th>Species</th>
+		<td>Seed Pokémon</td>
+	</tr>
+	<tr>
+		<th>Height</th>
+		<td>0.7&nbsp;m (2&#8242;04&#8243;)</td>
+	</tr>
+	<tr>
+		<th>Weight</th>
+		<td>6.9&nbsp;kg (15.2&nbsp;lbs)</td>
+	</tr>
+	<tr>
+		<th>Abilities</th>
+		<td><span class="text-muted">1. <a href="/ability/overgrow" title="Powers up Grass-type moves in a pinch.">Overgrow</a></span><br><small class="text-muted"><a href="/ability/chlorophyll" title="Boosts the Pokémon&#039;s Speed in sunshine.">Chlorophyll</a> (hidden ability)</small><br></td>
+	</tr>
+	<tr>
+		<th>Local &#8470;</th>
+		<td>0001 <small class="text-muted">(Red/Blue/Yellow)</small><br>0226 <small class="text-muted">(Gold/Silver/Crystal)</small><br>0001 <small class="text-muted">(FireRed/LeafGreen)</small><br>0231 <small class="text-muted">(HeartGold/SoulSilver)</small><br>0080 <small class="text-muted">(X/Y &mdash; Central Kalos)</small><br>0001 <small class="text-muted">(Let's Go Pikachu/Let's Go Eevee)</small><br>0068 <small class="text-muted">(The Isle of Armor)</small><br>0164 <small class="text-muted">(The Indigo Disk)</small><br></td>
+	</tr>
+	</tbody>
+</table>
+				</div>
+
+				<div class="grid-col span-md-12 span-lg-4">
+					<div class="grid-row">
+						<div class="grid-col span-md-6 span-lg-12">
+						<h2>Training</h2>
+
+<table class="vitals-table">
+	<tbody>
+	<tr>
+		<th>EV yield</th>
+		<td class="text">
+			1 Sp. Atk		</td>
+	</tr>
+	<tr>
+		<th>Catch rate</th>
+		<td>
+					45 <small class="text-muted">(5.9% with PokéBall, full HP)</small>
+				</td>
+	</tr>
+	<tr>
+		<th>Base <a href="/glossary#def-friendship">Friendship</a></th>
+		<td>
+					50 <small class="text-muted">(normal)</small>
+				</td>
+	</tr>
+	<tr>
+		<th>Base Exp.</th>
+		<td>64</td>
+	</tr>
+	<tr>
+		<th>Growth Rate</th>
+		<td>Medium Slow</td>
+	</tr>
+	</tbody>
+</table>
+						</div>
+						<div class="grid-col span-md-6 span-lg-12">
+							<h2>Breeding</h2>
+
+<table class="vitals-table">
+	<tbody>
+	<tr>
+		<th>Egg Groups</th>
+		<td><a href="/egg-group/grass">Grass</a>, <a href="/egg-group/monster">Monster</a></td>
+	</tr>
+	<tr>
+		<th>Gender</th>
+		<td><span class="text-blue">87.5% male</span>, <span class="text-pink">12.5% female</span></td>	</tr>
+	<tr>
+		<th><a href="/glossary#def-eggcycle">Egg cycles</a></th>
+					<td>20				<small class="text-muted">(4,884&ndash;5,140 steps)</small>
+			</td>
+			</tr>
+	</tbody>
+</table>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="grid-row">
+				<div class="grid-col span-md-12 span-lg-8">
+					<div id="dex-stats"></div>
+					<h2>Base stats</h2>
+											<div class="resp-scroll">
+	<table class="vitals-table">
+		<tbody>
+					<tr>
+				<th>HP</th>
+				<td class="cell-num">45</td>
+				<td class="cell-barchart">
+					<div style="width:25.00%;"							class="barchart-bar barchart-rank-2 "></div>
+				</td>
+				<td class="cell-num">200</td>
+				<td class="cell-num">294</td>
+			</tr>
+					<tr>
+				<th>Attack</th>
+				<td class="cell-num">49</td>
+				<td class="cell-barchart">
+					<div style="width:27.22%;"							class="barchart-bar barchart-rank-2 "></div>
+				</td>
+				<td class="cell-num">92</td>
+				<td class="cell-num">216</td>
+			</tr>
+					<tr>
+				<th>Defense</th>
+				<td class="cell-num">49</td>
+				<td class="cell-barchart">
+					<div style="width:27.22%;"							class="barchart-bar barchart-rank-2 "></div>
+				</td>
+				<td class="cell-num">92</td>
+				<td class="cell-num">216</td>
+			</tr>
+					<tr>
+				<th>Sp. Atk</th>
+				<td class="cell-num">65</td>
+				<td class="cell-barchart">
+					<div style="width:36.11%;"							class="barchart-bar barchart-rank-3 "></div>
+				</td>
+				<td class="cell-num">121</td>
+				<td class="cell-num">251</td>
+			</tr>
+					<tr>
+				<th>Sp. Def</th>
+				<td class="cell-num">65</td>
+				<td class="cell-barchart">
+					<div style="width:36.11%;"							class="barchart-bar barchart-rank-3 "></div>
+				</td>
+				<td class="cell-num">121</td>
+				<td class="cell-num">251</td>
+			</tr>
+					<tr>
+				<th>Speed</th>
+				<td class="cell-num">45</td>
+				<td class="cell-barchart">
+					<div style="width:25.00%;"							class="barchart-bar barchart-rank-2 "></div>
+				</td>
+				<td class="cell-num">85</td>
+				<td class="cell-num">207</td>
+			</tr>
+				</tbody>
+		<tfoot>
+		<tr>
+			<th>Total</th>
+			<td class="cell-num cell-total">318</td>
+			<th class="cell-barchart"></th>
+			<th>Min</th>
+			<th>Max</th>
+		</tr>
+		</tfoot>
+	</table>
+</div>
+						<p class="text-small text-muted">The ranges shown on the right are for a level 100 Pokémon. Maximum values are based on a beneficial nature, 252 EVs, 31 IVs; minimum values are based on a hindering nature, 0 EVs, 0 IVs.</p>
+									</div>
+
+				<div class="grid-col span-md-12 span-lg-4">
+					<h2>Type defenses</h2>
+					<p>The effectiveness of each type on <em>Bulbasaur</em>.</p>
+					<div class="resp-scroll text-center"><table class="type-table type-table-pokedex"><tr><th><a class="type-icon type-normal type-cell type-abbr"  href="/type/normal"  title="Normal" >Nor</a></th><th><a class="type-icon type-fire type-cell type-abbr"  href="/type/fire"  title="Fire" >Fir</a></th><th><a class="type-icon type-water type-cell type-abbr"  href="/type/water"  title="Water" >Wat</a></th><th><a class="type-icon type-electric type-cell type-abbr"  href="/type/electric"  title="Electric" >Ele</a></th><th><a class="type-icon type-grass type-cell type-abbr"  href="/type/grass"  title="Grass" >Gra</a></th><th><a class="type-icon type-ice type-cell type-abbr"  href="/type/ice"  title="Ice" >Ice</a></th><th><a class="type-icon type-fighting type-cell type-abbr"  href="/type/fighting"  title="Fighting" >Fig</a></th><th><a class="type-icon type-poison type-cell type-abbr"  href="/type/poison"  title="Poison" >Poi</a></th><th><a class="type-icon type-ground type-cell type-abbr"  href="/type/ground"  title="Ground" >Gro</a></th></tr>
+<tr><td title="Normal &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Fire &#8594; Grass/Poison = super-effective" class="type-fx-cell type-fx-200">2</td><td title="Water &#8594; Grass/Poison = not very effective" class="type-fx-cell type-fx-50">&frac12;</td><td title="Electric &#8594; Grass/Poison = not very effective" class="type-fx-cell type-fx-50">&frac12;</td><td title="Grass &#8594; Grass/Poison = not very effective" class="type-fx-cell type-fx-25">&frac14;</td><td title="Ice &#8594; Grass/Poison = super-effective" class="type-fx-cell type-fx-200">2</td><td title="Fighting &#8594; Grass/Poison = not very effective" class="type-fx-cell type-fx-50">&frac12;</td><td title="Poison &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Ground &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td></tr>
+</table><table class="type-table type-table-pokedex"><tr><th><a class="type-icon type-flying type-cell type-abbr"  href="/type/flying"  title="Flying" >Fly</a></th><th><a class="type-icon type-psychic type-cell type-abbr"  href="/type/psychic"  title="Psychic" >Psy</a></th><th><a class="type-icon type-bug type-cell type-abbr"  href="/type/bug"  title="Bug" >Bug</a></th><th><a class="type-icon type-rock type-cell type-abbr"  href="/type/rock"  title="Rock" >Roc</a></th><th><a class="type-icon type-ghost type-cell type-abbr"  href="/type/ghost"  title="Ghost" >Gho</a></th><th><a class="type-icon type-dragon type-cell type-abbr"  href="/type/dragon"  title="Dragon" >Dra</a></th><th><a class="type-icon type-dark type-cell type-abbr"  href="/type/dark"  title="Dark" >Dar</a></th><th><a class="type-icon type-steel type-cell type-abbr"  href="/type/steel"  title="Steel" >Ste</a></th><th><a class="type-icon type-fairy type-cell type-abbr"  href="/type/fairy"  title="Fairy" >Fai</a></th></tr>
+<tr><td title="Flying &#8594; Grass/Poison = super-effective" class="type-fx-cell type-fx-200">2</td><td title="Psychic &#8594; Grass/Poison = super-effective" class="type-fx-cell type-fx-200">2</td><td title="Bug &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Rock &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Ghost &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Dragon &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Dark &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Steel &#8594; Grass/Poison = normal effectiveness" class="type-fx-cell type-fx-100"></td><td title="Fairy &#8594; Grass/Poison = not very effective" class="type-fx-cell type-fx-50">&frac12;</td></tr>
+</table></div>				</div>
+			</div>
+
+		</div>
+		</div>
+</div>
+
+
+<div id="dex-evolution"></div>
+<h2>Evolution chart</h2>
+
+	<div class="infocard-list-evo"><div class="infocard "><span class="infocard-lg-img"><a href="/pokedex/bulbasaur"><picture><source srcset="https://img.pokemondb.net/sprites/home/normal/2x/avif/bulbasaur.avif" type="image/avif"><img class="img-fixed img-sprite" src="https://img.pokemondb.net/sprites/home/normal/2x/bulbasaur.jpg" alt="Bulbasaur" loading="lazy"></picture></a></span><span class="infocard-lg-data text-muted"><small>#0001</small><br> <a class="ent-name" href="/pokedex/bulbasaur">Bulbasaur</a><br> <small><a href="/type/grass" class="itype grass">Grass</a> &middot; <a href="/type/poison" class="itype poison">Poison</a></small></span></div>
+<span class="infocard infocard-arrow"><i class="icon-arrow icon-arrow-e"></i><small>(Level 16)</small></span><div class="infocard "><span class="infocard-lg-img"><a href="/pokedex/ivysaur"><picture><source srcset="https://img.pokemondb.net/sprites/home/normal/2x/avif/ivysaur.avif" type="image/avif"><img class="img-fixed img-sprite" src="https://img.pokemondb.net/sprites/home/normal/2x/ivysaur.jpg" alt="Ivysaur" loading="lazy"></picture></a></span><span class="infocard-lg-data text-muted"><small>#0002</small><br> <a class="ent-name" href="/pokedex/ivysaur">Ivysaur</a><br> <small><a href="/type/grass" class="itype grass">Grass</a> &middot; <a href="/type/poison" class="itype poison">Poison</a></small></span></div>
+<span class="infocard infocard-arrow"><i class="icon-arrow icon-arrow-e"></i><small>(Level 32)</small></span><div class="infocard "><span class="infocard-lg-img"><a href="/pokedex/venusaur"><picture><source srcset="https://img.pokemondb.net/sprites/home/normal/2x/avif/venusaur.avif" type="image/avif"><img class="img-fixed img-sprite" src="https://img.pokemondb.net/sprites/home/normal/2x/venusaur.jpg" alt="Venusaur" loading="lazy"></picture></a></span><span class="infocard-lg-data text-muted"><small>#0003</small><br> <a class="ent-name" href="/pokedex/venusaur">Venusaur</a><br> <small><a href="/type/grass" class="itype grass">Grass</a> &middot; <a href="/type/poison" class="itype poison">Poison</a></small></span></div>
+</div>
+
+	<h2>Bulbasaur changes</h2>
+	<ul>
+			<li>In <abbr title="Pokémon Red, Blue &amp; Yellow">Generation 1</abbr>, <em>Bulbasaur</em> has a base Special stat of 65.</li>
+			<li>In <abbr title="(2) Pokémon Gold, Silver &amp; Crystal
+(3) Pokémon Ruby, Sapphire, FireRed, LeafGreen &amp; Emerald
+(4) Pokémon Diamond, Pearl, Platinum, HeartGold &amp; SoulSilver
+(5) Pokémon Black, White, Black 2 &amp; White 2
+(6) Pokémon X, Y, Omega Ruby &amp; Alpha Sapphire
+(7) Pokémon Sun, Moon, Ultra Sun &amp; Ultra Moon">Generations 2-7</abbr>, <em>Bulbasaur</em> has a base Friendship value of 70.</li>
+		</ul>
+
+
+<div id="dex-flavor"></div>
+	<h2>Pokédex entries</h2>
+	<div class="resp-scroll"><table class="vitals-table"><tbody><tr>
+	<th><span class="igame red">Red</span><br><span class="igame blue">Blue</span></th>
+	<td class="cell-med-text">A strange seed was planted on its back at birth. The plant sprouts and grows with this POKéMON.</td>
+</tr>
+<tr>
+	<th><span class="igame yellow">Yellow</span></th>
+	<td class="cell-med-text">It can go for days without eating a single morsel. In the bulb on its back, it stores energy.</td>
+</tr>
+<tr>
+	<th><span class="igame gold">Gold</span></th>
+	<td class="cell-med-text">The seed on its back is filled with nutrients. The seed grows steadily larger as its body grows.</td>
+</tr>
+<tr>
+	<th><span class="igame silver">Silver</span></th>
+	<td class="cell-med-text">It carries a seed on its back right from birth. As it grows older, the seed also grows larger.</td>
+</tr>
+<tr>
+	<th><span class="igame crystal">Crystal</span></th>
+	<td class="cell-med-text">While it is young, it uses the nutrients that are stored in the seeds on its back in order to grow.</td>
+</tr>
+<tr>
+	<th><span class="igame ruby">Ruby</span><br><span class="igame sapphire">Sapphire</span><br><span class="igame emerald">Emerald</span></th>
+	<td class="cell-med-text">BULBASAUR can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun’s rays, the seed grows progressively larger.</td>
+</tr>
+<tr>
+	<th><span class="igame firered">FireRed</span></th>
+	<td class="cell-med-text">There is a plant seed on its back right from the day this POKéMON is born. The seed slowly grows larger.</td>
+</tr>
+<tr>
+	<th><span class="igame leafgreen">LeafGreen</span></th>
+	<td class="cell-med-text">A strange seed was planted on its back at birth. The plant sprouts and grows with this POKéMON.</td>
+</tr>
+<tr>
+	<th><span class="igame diamond">Diamond</span><br><span class="igame pearl">Pearl</span><br><span class="igame platinum">Platinum</span></th>
+	<td class="cell-med-text">For some time after its birth, it grows by gaining nourishment from the seed on its back.</td>
+</tr>
+<tr>
+	<th><span class="igame heartgold">HeartGold</span></th>
+	<td class="cell-med-text">The seed on its back is filled with nutrients. The seed grows steadily larger as its body grows.</td>
+</tr>
+<tr>
+	<th><span class="igame soulsilver">SoulSilver</span></th>
+	<td class="cell-med-text">It carries a seed on its back right from birth. As it grows older, the seed also grows larger.</td>
+</tr>
+<tr>
+	<th><span class="igame black">Black</span><br><span class="igame white">White</span><br><span class="igame black-2">Black 2</span><br><span class="igame white-2">White 2</span></th>
+	<td class="cell-med-text">For some time after its birth, it grows by gaining nourishment from the seed on its back.</td>
+</tr>
+<tr>
+	<th><span class="igame x">X</span></th>
+	<td class="cell-med-text">A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.</td>
+</tr>
+<tr>
+	<th><span class="igame y">Y</span></th>
+	<td class="cell-med-text">For some time after its birth, it grows by gaining nourishment from the seed on its back.</td>
+</tr>
+<tr>
+	<th><span class="igame omega-ruby">Omega Ruby</span><br><span class="igame alpha-sapphire">Alpha Sapphire</span></th>
+	<td class="cell-med-text">Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun’s rays, the seed grows progressively larger.</td>
+</tr>
+<tr>
+	<th><span class="igame lets-go-pikachu">Let's Go Pikachu</span><br><span class="igame lets-go-eevee">Let's Go Eevee</span></th>
+	<td class="cell-med-text">It can go for days without eating a single morsel. In the bulb on its back, it stores energy.</td>
+</tr>
+<tr>
+	<th><span class="igame sword">Sword</span></th>
+	<td class="cell-med-text">There is a plant seed on its back right from the day this Pokémon is born. The seed slowly grows larger.</td>
+</tr>
+<tr>
+	<th><span class="igame shield">Shield</span></th>
+	<td class="cell-med-text">While it is young, it uses the nutrients that are stored in the seed on its back in order to grow.</td>
+</tr>
+<tr>
+	<th><span class="igame brilliant-diamond">Brilliant Diamond</span><br><span class="igame shining-pearl">Shining Pearl</span></th>
+	<td class="cell-med-text">For some time after its birth, it grows by taking nourishment from the seed on its back.</td>
+</tr>
+</tbody></table></div>
+
+<div id="dex-moves"></div>
+<h2>Moves learned by Bulbasaur</h2>
+
+	<ul class="list-nav panel panel-nav"><li class="list-nav-title">In other generations</li><li><a title="Generation 1: Red, Blue, Yellow" href="/pokedex/bulbasaur/moves/1">1</a></li> <li><a title="Generation 2: Gold, Silver, Crystal" href="/pokedex/bulbasaur/moves/2">2</a></li> <li><a title="Generation 3: Ruby, Sapphire, FireRed, LeafGreen, Emerald" href="/pokedex/bulbasaur/moves/3">3</a></li> <li><a title="Generation 4: Diamond, Pearl, Platinum, HeartGold, SoulSilver" href="/pokedex/bulbasaur/moves/4">4</a></li> <li><a title="Generation 5: Black, White, Black 2, White 2" href="/pokedex/bulbasaur/moves/5">5</a></li> <li><a title="Generation 6: X, Y, Omega Ruby, Alpha Sapphire" href="/pokedex/bulbasaur/moves/6">6</a></li> <li><a title="Generation 7: Sun, Moon, Ultra Sun, Ultra Moon, Let's Go Pikachu, Let's Go Eevee" href="/pokedex/bulbasaur/moves/7">7</a></li> <li><a title="Generation 8: Sword, Shield, Brilliant Diamond, Shining Pearl, Legends: Arceus" href="/pokedex/bulbasaur/moves/8">8</a></li> <li><a title="Generation 9: Scarlet, Violet" href="/pokedex/bulbasaur/moves/9">9</a></li> </ul>
+	<div class="tabset-moves-game sv-tabs-wrapper">
+		<div class="sv-tabs-tab-list">
+					<a class="sv-tabs-tab active" href="#tab-moves-21">Scarlet/Violet</a>
+					<a class="sv-tabs-tab " href="#tab-moves-19">Brilliant Diamond/Shining Pearl</a>
+				</div>
+
+		<div class="sv-tabs-panel-list">
+					<div class="sv-tabs-panel active" id="tab-moves-21">
+				<div class="grid-row"> <div class="grid-col span-lg-6"><h3>Moves learnt by level up</h3> <p class="text-small"><em>Bulbasaur</em> learns the following moves in Pokémon Scarlet &amp; Violet at the levels specified.</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="int"><div class="sortwrap">Lv.</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-num">1</td><td class="cell-name"><a class="ent-name" href="/move/growl" title="View details for Growl">Growl</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">1</td><td class="cell-name"><a class="ent-name" href="/move/tackle" title="View details for Tackle">Tackle</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">3</td><td class="cell-name"><a class="ent-name" href="/move/vine-whip" title="View details for Vine Whip">Vine Whip</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">45</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">6</td><td class="cell-name"><a class="ent-name" href="/move/growth" title="View details for Growth">Growth</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num">9</td><td class="cell-name"><a class="ent-name" href="/move/leech-seed" title="View details for Leech Seed">Leech Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-num">12</td><td class="cell-name"><a class="ent-name" href="/move/razor-leaf" title="View details for Razor Leaf">Razor Leaf</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">55</td> <td class="cell-num" >95</td> 
+</tr><tr><td class="cell-num">15</td><td class="cell-name"><a class="ent-name" href="/move/poison-powder" title="View details for Poison Powder">Poison Powder</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >75</td> 
+</tr><tr><td class="cell-num">15</td><td class="cell-name"><a class="ent-name" href="/move/sleep-powder" title="View details for Sleep Powder">Sleep Powder</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >75</td> 
+</tr><tr><td class="cell-num">18</td><td class="cell-name"><a class="ent-name" href="/move/seed-bomb" title="View details for Seed Bomb">Seed Bomb</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">21</td><td class="cell-name"><a class="ent-name" href="/move/take-down" title="View details for Take Down">Take Down</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-num">24</td><td class="cell-name"><a class="ent-name" href="/move/sweet-scent" title="View details for Sweet Scent">Sweet Scent</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">27</td><td class="cell-name"><a class="ent-name" href="/move/synthesis" title="View details for Synthesis">Synthesis</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num">30</td><td class="cell-name"><a class="ent-name" href="/move/worry-seed" title="View details for Worry Seed">Worry Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">33</td><td class="cell-name"><a class="ent-name" href="/move/power-whip" title="View details for Power Whip">Power Whip</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-num">36</td><td class="cell-name"><a class="ent-name" href="/move/solar-beam" title="View details for Solar Beam">Solar Beam</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr></tbody></table></div><h3>Egg moves</h3> <p class="text-small"><em>Bulbasaur</em> learns the following moves via breeding or picnics in Pokémon Scarlet &amp; Violet. Details and compatible parents can be found on the <a href="/pokedex/bulbasaur/moves/9#egg-move-parents">Bulbasaur gen 9 learnset</a> page.</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-name"><a class="ent-name" href="/move/curse" title="View details for Curse">Curse</a></td><td class="cell-icon"><a class="type-icon type-ghost"  href="/type/ghost" >Ghost</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/ingrain" title="View details for Ingrain">Ingrain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/petal-dance" title="View details for Petal Dance">Petal Dance</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/toxic" title="View details for Toxic">Toxic</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >90</td> 
+</tr></tbody></table></div></div> <div class="grid-col span-lg-6"><h3>Moves learnt by TM</h3> <p class="text-small"><em>Bulbasaur</em> is compatible with these Technical Machines in Pokémon Scarlet &amp; Violet:</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="int"><div class="sortwrap">TM</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-num"><a href="/item/tm01" title="TM01">01</a></td><td class="cell-name"><a class="ent-name" href="/move/take-down" title="View details for Take Down">Take Down</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm02" title="TM02">02</a></td><td class="cell-name"><a class="ent-name" href="/move/charm" title="View details for Charm">Charm</a></td><td class="cell-icon"><a class="type-icon type-fairy"  href="/type/fairy" >Fairy</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm07" title="TM07">07</a></td><td class="cell-name"><a class="ent-name" href="/move/protect" title="View details for Protect">Protect</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm13" title="TM13">13</a></td><td class="cell-name"><a class="ent-name" href="/move/acid-spray" title="View details for Acid Spray">Acid Spray</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm20" title="TM20">20</a></td><td class="cell-name"><a class="ent-name" href="/move/trailblaze" title="View details for Trailblaze">Trailblaze</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">50</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm25" title="TM25">25</a></td><td class="cell-name"><a class="ent-name" href="/move/facade" title="View details for Facade">Facade</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">70</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm33" title="TM33">33</a></td><td class="cell-name"><a class="ent-name" href="/move/magical-leaf" title="View details for Magical Leaf">Magical Leaf</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">60</td> <td class="cell-num num-infinity" data-sort-value="101">&infin;</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm45" title="TM45">45</a></td><td class="cell-name"><a class="ent-name" href="/move/venoshock" title="View details for Venoshock">Venoshock</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">65</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm47" title="TM47">47</a></td><td class="cell-name"><a class="ent-name" href="/move/endure" title="View details for Endure">Endure</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm49" title="TM49">49</a></td><td class="cell-name"><a class="ent-name" href="/move/sunny-day" title="View details for Sunny Day">Sunny Day</a></td><td class="cell-icon"><a class="type-icon type-fire"  href="/type/fire" >Fire</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm56" title="TM56">56</a></td><td class="cell-name"><a class="ent-name" href="/move/bullet-seed" title="View details for Bullet Seed">Bullet Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">25</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm57" title="TM57">57</a></td><td class="cell-name"><a class="ent-name" href="/move/false-swipe" title="View details for False Swipe">False Swipe</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm66" title="TM66">66</a></td><td class="cell-name"><a class="ent-name" href="/move/body-slam" title="View details for Body Slam">Body Slam</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">85</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm70" title="TM70">70</a></td><td class="cell-name"><a class="ent-name" href="/move/sleep-talk" title="View details for Sleep Talk">Sleep Talk</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm71" title="TM71">71</a></td><td class="cell-name"><a class="ent-name" href="/move/seed-bomb" title="View details for Seed Bomb">Seed Bomb</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm81" title="TM81">81</a></td><td class="cell-name"><a class="ent-name" href="/move/grass-knot" title="View details for Grass Knot">Grass Knot</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm85" title="TM85">85</a></td><td class="cell-name"><a class="ent-name" href="/move/rest" title="View details for Rest">Rest</a></td><td class="cell-icon"><a class="type-icon type-psychic"  href="/type/psychic" >Psychic</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm88" title="TM88">88</a></td><td class="cell-name"><a class="ent-name" href="/move/swords-dance" title="View details for Swords Dance">Swords Dance</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm103" title="TM103">103</a></td><td class="cell-name"><a class="ent-name" href="/move/substitute" title="View details for Substitute">Substitute</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm111" title="TM111">111</a></td><td class="cell-name"><a class="ent-name" href="/move/giga-drain" title="View details for Giga Drain">Giga Drain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">75</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm119" title="TM119">119</a></td><td class="cell-name"><a class="ent-name" href="/move/energy-ball" title="View details for Energy Ball">Energy Ball</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm130" title="TM130">130</a></td><td class="cell-name"><a class="ent-name" href="/move/helping-hand" title="View details for Helping Hand">Helping Hand</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm137" title="TM137">137</a></td><td class="cell-name"><a class="ent-name" href="/move/grassy-terrain" title="View details for Grassy Terrain">Grassy Terrain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm146" title="TM146">146</a></td><td class="cell-name"><a class="ent-name" href="/move/grass-pledge" title="View details for Grass Pledge">Grass Pledge</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm148" title="TM148">148</a></td><td class="cell-name"><a class="ent-name" href="/move/sludge-bomb" title="View details for Sludge Bomb">Sludge Bomb</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm159" title="TM159">159</a></td><td class="cell-name"><a class="ent-name" href="/move/leaf-storm" title="View details for Leaf Storm">Leaf Storm</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">130</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm168" title="TM168">168</a></td><td class="cell-name"><a class="ent-name" href="/move/solar-beam" title="View details for Solar Beam">Solar Beam</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm171" title="TM171">171</a></td><td class="cell-name"><a class="ent-name" href="/move/tera-blast" title="View details for Tera Blast">Tera Blast</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm175" title="TM175">175</a></td><td class="cell-name"><a class="ent-name" href="/move/toxic" title="View details for Toxic">Toxic</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm181" title="TM181">181</a></td><td class="cell-name"><a class="ent-name" href="/move/knock-off" title="View details for Knock Off">Knock Off</a></td><td class="cell-icon"><a class="type-icon type-dark"  href="/type/dark" >Dark</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">65</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm193" title="TM193">193</a></td><td class="cell-name"><a class="ent-name" href="/move/weather-ball" title="View details for Weather Ball">Weather Ball</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">50</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm194" title="TM194">194</a></td><td class="cell-name"><a class="ent-name" href="/move/grassy-glide" title="View details for Grassy Glide">Grassy Glide</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">55</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm204" title="TM204">204</a></td><td class="cell-name"><a class="ent-name" href="/move/double-edge" title="View details for Double-Edge">Double-Edge</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm224" title="TM224">224</a></td><td class="cell-name"><a class="ent-name" href="/move/curse" title="View details for Curse">Curse</a></td><td class="cell-icon"><a class="type-icon type-ghost"  href="/type/ghost" >Ghost</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr></tbody></table></div></div> </div>			</div>
+					<div class="sv-tabs-panel " id="tab-moves-19">
+				<div class="grid-row"> <div class="grid-col span-lg-6"><h3>Moves learnt by level up</h3> <p class="text-small"><em>Bulbasaur</em> learns the following moves in Pokémon Brilliant Diamond &amp; Shining Pearl at the levels specified.</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="int"><div class="sortwrap">Lv.</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-num">1</td><td class="cell-name"><a class="ent-name" href="/move/growl" title="View details for Growl">Growl</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">1</td><td class="cell-name"><a class="ent-name" href="/move/tackle" title="View details for Tackle">Tackle</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">3</td><td class="cell-name"><a class="ent-name" href="/move/vine-whip" title="View details for Vine Whip">Vine Whip</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">45</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">6</td><td class="cell-name"><a class="ent-name" href="/move/growth" title="View details for Growth">Growth</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num">9</td><td class="cell-name"><a class="ent-name" href="/move/leech-seed" title="View details for Leech Seed">Leech Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-num">12</td><td class="cell-name"><a class="ent-name" href="/move/razor-leaf" title="View details for Razor Leaf">Razor Leaf</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">55</td> <td class="cell-num" >95</td> 
+</tr><tr><td class="cell-num">15</td><td class="cell-name"><a class="ent-name" href="/move/poison-powder" title="View details for Poison Powder">Poison Powder</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >75</td> 
+</tr><tr><td class="cell-num">15</td><td class="cell-name"><a class="ent-name" href="/move/sleep-powder" title="View details for Sleep Powder">Sleep Powder</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >75</td> 
+</tr><tr><td class="cell-num">18</td><td class="cell-name"><a class="ent-name" href="/move/seed-bomb" title="View details for Seed Bomb">Seed Bomb</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">21</td><td class="cell-name"><a class="ent-name" href="/move/take-down" title="View details for Take Down">Take Down</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-num">24</td><td class="cell-name"><a class="ent-name" href="/move/sweet-scent" title="View details for Sweet Scent">Sweet Scent</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">27</td><td class="cell-name"><a class="ent-name" href="/move/synthesis" title="View details for Synthesis">Synthesis</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num">30</td><td class="cell-name"><a class="ent-name" href="/move/worry-seed" title="View details for Worry Seed">Worry Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">33</td><td class="cell-name"><a class="ent-name" href="/move/double-edge" title="View details for Double-Edge">Double-Edge</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num">36</td><td class="cell-name"><a class="ent-name" href="/move/solar-beam" title="View details for Solar Beam">Solar Beam</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr></tbody></table></div><h3>Egg moves</h3> <p class="text-small"><em>Bulbasaur</em> learns the following moves via breeding in Pokémon Brilliant Diamond &amp; Shining Pearl. Details and compatible parents can be found on the <a href="/pokedex/bulbasaur/moves/8#egg-move-parents">Bulbasaur gen 8 learnset</a> page.</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-name"><a class="ent-name" href="/move/amnesia" title="View details for Amnesia">Amnesia</a></td><td class="cell-icon"><a class="type-icon type-psychic"  href="/type/psychic" >Psychic</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/charm" title="View details for Charm">Charm</a></td><td class="cell-icon"><a class="type-icon type-fairy"  href="/type/fairy" >Fairy</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/curse" title="View details for Curse">Curse</a></td><td class="cell-icon"><a class="type-icon type-ghost"  href="/type/ghost" >Ghost</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/grassy-terrain" title="View details for Grassy Terrain">Grassy Terrain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/ingrain" title="View details for Ingrain">Ingrain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/leaf-storm" title="View details for Leaf Storm">Leaf Storm</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">130</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/magical-leaf" title="View details for Magical Leaf">Magical Leaf</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">60</td> <td class="cell-num num-infinity" data-sort-value="101">&infin;</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/nature-power" title="View details for Nature Power">Nature Power</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/petal-dance" title="View details for Petal Dance">Petal Dance</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/power-whip" title="View details for Power Whip">Power Whip</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/skull-bash" title="View details for Skull Bash">Skull Bash</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">130</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-name"><a class="ent-name" href="/move/sludge" title="View details for Sludge">Sludge</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">65</td> <td class="cell-num" >100</td> 
+</tr></tbody></table></div></div> <div class="grid-col span-lg-6"><h3>Moves learnt by TM</h3> <p class="text-small"><em>Bulbasaur</em> is compatible with these Technical Machines in Pokémon Brilliant Diamond &amp; Shining Pearl:</p> <div class="resp-scroll"><table class="data-table"><thead><tr><th class="sorting" data-sort-type="int"><div class="sortwrap">TM</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Move</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Type</div></th> <th class="sorting" data-sort-type="string"><div class="sortwrap">Cat.</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Power</div></th> <th class="sorting" data-sort-type="int" data-sort-default="desc" data-blanks="1"><div class="sortwrap">Acc.</div></th> </tr></thead><tbody><tr><td class="cell-num"><a href="/item/tm06" title="TM06">06</a></td><td class="cell-name"><a class="ent-name" href="/move/toxic" title="View details for Toxic">Toxic</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >90</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm09" title="TM09">09</a></td><td class="cell-name"><a class="ent-name" href="/move/bullet-seed" title="View details for Bullet Seed">Bullet Seed</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">25</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm10" title="TM10">10</a></td><td class="cell-name"><a class="ent-name" href="/move/work-up" title="View details for Work Up">Work Up</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm11" title="TM11">11</a></td><td class="cell-name"><a class="ent-name" href="/move/sunny-day" title="View details for Sunny Day">Sunny Day</a></td><td class="cell-icon"><a class="type-icon type-fire"  href="/type/fire" >Fire</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm16" title="TM16">16</a></td><td class="cell-name"><a class="ent-name" href="/move/light-screen" title="View details for Light Screen">Light Screen</a></td><td class="cell-icon"><a class="type-icon type-psychic"  href="/type/psychic" >Psychic</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm17" title="TM17">17</a></td><td class="cell-name"><a class="ent-name" href="/move/protect" title="View details for Protect">Protect</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm19" title="TM19">19</a></td><td class="cell-name"><a class="ent-name" href="/move/giga-drain" title="View details for Giga Drain">Giga Drain</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">75</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm20" title="TM20">20</a></td><td class="cell-name"><a class="ent-name" href="/move/safeguard" title="View details for Safeguard">Safeguard</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm22" title="TM22">22</a></td><td class="cell-name"><a class="ent-name" href="/move/solar-beam" title="View details for Solar Beam">Solar Beam</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">120</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm32" title="TM32">32</a></td><td class="cell-name"><a class="ent-name" href="/move/double-team" title="View details for Double Team">Double Team</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm36" title="TM36">36</a></td><td class="cell-name"><a class="ent-name" href="/move/sludge-bomb" title="View details for Sludge Bomb">Sludge Bomb</a></td><td class="cell-icon"><a class="type-icon type-poison"  href="/type/poison" >Poison</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm42" title="TM42">42</a></td><td class="cell-name"><a class="ent-name" href="/move/facade" title="View details for Facade">Facade</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">70</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm44" title="TM44">44</a></td><td class="cell-name"><a class="ent-name" href="/move/rest" title="View details for Rest">Rest</a></td><td class="cell-icon"><a class="type-icon type-psychic"  href="/type/psychic" >Psychic</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm45" title="TM45">45</a></td><td class="cell-name"><a class="ent-name" href="/move/attract" title="View details for Attract">Attract</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm53" title="TM53">53</a></td><td class="cell-name"><a class="ent-name" href="/move/energy-ball" title="View details for Energy Ball">Energy Ball</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">90</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm54" title="TM54">54</a></td><td class="cell-name"><a class="ent-name" href="/move/false-swipe" title="View details for False Swipe">False Swipe</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm58" title="TM58">58</a></td><td class="cell-name"><a class="ent-name" href="/move/endure" title="View details for Endure">Endure</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm70" title="TM70">70</a></td><td class="cell-name"><a class="ent-name" href="/move/flash" title="View details for Flash">Flash</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm75" title="TM75">75</a></td><td class="cell-name"><a class="ent-name" href="/move/swords-dance" title="View details for Swords Dance">Swords Dance</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm82" title="TM82">82</a></td><td class="cell-name"><a class="ent-name" href="/move/sleep-talk" title="View details for Sleep Talk">Sleep Talk</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm86" title="TM86">86</a></td><td class="cell-name"><a class="ent-name" href="/move/grass-knot" title="View details for Grass Knot">Grass Knot</a></td><td class="cell-icon"><a class="type-icon type-grass"  href="/type/grass" >Grass</a></td><td class="cell-icon text-center" data-sort-value="special" data-filter-value="special"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-special.png" width="30" height="20" alt="Special" title="Special" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm87" title="TM87">87</a></td><td class="cell-name"><a class="ent-name" href="/move/swagger" title="View details for Swagger">Swagger</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >85</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm90" title="TM90">90</a></td><td class="cell-name"><a class="ent-name" href="/move/substitute" title="View details for Substitute">Substitute</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="status" data-filter-value="status"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-status.png" width="30" height="20" alt="Status" title="Status" loading="lazy"></td> <td class="cell-num">—</td> <td class="cell-num" >—</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm93" title="TM93">93</a></td><td class="cell-name"><a class="ent-name" href="/move/cut" title="View details for Cut">Cut</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">50</td> <td class="cell-num" >95</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm96" title="TM96">96</a></td><td class="cell-name"><a class="ent-name" href="/move/strength" title="View details for Strength">Strength</a></td><td class="cell-icon"><a class="type-icon type-normal"  href="/type/normal" >Normal</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">80</td> <td class="cell-num" >100</td> 
+</tr><tr><td class="cell-num"><a href="/item/tm98" title="TM98">98</a></td><td class="cell-name"><a class="ent-name" href="/move/rock-smash" title="View details for Rock Smash">Rock Smash</a></td><td class="cell-icon"><a class="type-icon type-fighting"  href="/type/fighting" >Fighting</a></td><td class="cell-icon text-center" data-sort-value="physical" data-filter-value="physical"><img class="img-fixed" src="https://img.pokemondb.net/images/icons/move-physical.png" width="30" height="20" alt="Physical" title="Physical" loading="lazy"></td> <td class="cell-num">40</td> <td class="cell-num" >100</td> 
+</tr></tbody></table></div></div> </div>			</div>
+				</div>
+	</div>
+
+	<ul class="list-nav panel panel-nav"><li class="list-nav-title">In other generations</li><li><a title="Generation 1: Red, Blue, Yellow" href="/pokedex/bulbasaur/moves/1">1</a></li> <li><a title="Generation 2: Gold, Silver, Crystal" href="/pokedex/bulbasaur/moves/2">2</a></li> <li><a title="Generation 3: Ruby, Sapphire, FireRed, LeafGreen, Emerald" href="/pokedex/bulbasaur/moves/3">3</a></li> <li><a title="Generation 4: Diamond, Pearl, Platinum, HeartGold, SoulSilver" href="/pokedex/bulbasaur/moves/4">4</a></li> <li><a title="Generation 5: Black, White, Black 2, White 2" href="/pokedex/bulbasaur/moves/5">5</a></li> <li><a title="Generation 6: X, Y, Omega Ruby, Alpha Sapphire" href="/pokedex/bulbasaur/moves/6">6</a></li> <li><a title="Generation 7: Sun, Moon, Ultra Sun, Ultra Moon, Let's Go Pikachu, Let's Go Eevee" href="/pokedex/bulbasaur/moves/7">7</a></li> <li><a title="Generation 8: Sword, Shield, Brilliant Diamond, Shining Pearl, Legends: Arceus" href="/pokedex/bulbasaur/moves/8">8</a></li> <li><a title="Generation 9: Scarlet, Violet" href="/pokedex/bulbasaur/moves/9">9</a></li> </ul>
+
+<div id="dex-sprites"></div>
+<h2>Bulbasaur sprites</h2>
+	
+<div class="resp-scroll" style="overflow-x:auto">
+	<table class="data-table sprites-table sprites-history-table" data-pkname="Bulbasaur" data-pkalias="bulbasaur">
+	<thead>
+		<tr>
+			<th>Type</th>
+					<th>Generation 1</th>
+					<th>Generation 2</th>
+					<th>Generation 3</th>
+					<th>Generation 4</th>
+					<th>Generation 5</th>
+					<th>Generation 6</th>
+					<th>Generation 7</th>
+					<th>Generation 8</th>
+					<th>Generation 9</th>
+				</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><b>Normal</b></td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/red-blue/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v1" src="https://img.pokemondb.net/sprites/red-blue/normal/bulbasaur.png" alt="Bulbasaur sprite from Red &amp; Blue" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/silver/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v3" src="https://img.pokemondb.net/sprites/silver/normal/bulbasaur.png" alt="Bulbasaur sprite from Silver" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/ruby-sapphire/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v5" src="https://img.pokemondb.net/sprites/ruby-sapphire/normal/bulbasaur.png" alt="Bulbasaur sprite from Ruby &amp; Sapphire" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/diamond-pearl/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v8" src="https://img.pokemondb.net/sprites/diamond-pearl/normal/bulbasaur.png" alt="Bulbasaur sprite from Diamond &amp; Pearl" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/black-white/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v11" src="https://img.pokemondb.net/sprites/black-white/normal/bulbasaur.png" alt="Bulbasaur sprite from Black &amp; White" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/x-y/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v13" src="https://img.pokemondb.net/sprites/x-y/normal/bulbasaur.png" alt="Bulbasaur sprite from X &amp; Y" width="120" height="120" loading="lazy"></a>						</td>
+					<td class="text-center">
+							&mdash;
+						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/sword-shield/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v18" src="https://img.pokemondb.net/sprites/sword-shield/normal/bulbasaur.png" alt="Bulbasaur sprite from Sword &amp; Shield" width="120" height="112" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/scarlet-violet/normal/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v21" src="https://img.pokemondb.net/sprites/scarlet-violet/normal/1x/bulbasaur.png" alt="Bulbasaur sprite from Scarlet &amp; Violet" loading="lazy"></a>						</td>
+				</tr>
+		<tr>
+			<td><b>Shiny</b></td>
+					<td class="text-center">
+							&mdash;
+						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/silver/shiny/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v3" src="https://img.pokemondb.net/sprites/silver/shiny/bulbasaur.png" alt="Bulbasaur Shiny sprite from Silver" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/ruby-sapphire/shiny/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v5" src="https://img.pokemondb.net/sprites/ruby-sapphire/shiny/bulbasaur.png" alt="Bulbasaur Shiny sprite from Ruby &amp; Sapphire" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/diamond-pearl/shiny/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v8" src="https://img.pokemondb.net/sprites/diamond-pearl/shiny/bulbasaur.png" alt="Bulbasaur Shiny sprite from Diamond &amp; Pearl" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/black-white/shiny/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v11" src="https://img.pokemondb.net/sprites/black-white/shiny/bulbasaur.png" alt="Bulbasaur Shiny sprite from Black &amp; White" loading="lazy"></a>						</td>
+					<td class="text-center">
+							<a href="https://img.pokemondb.net/sprites/x-y/shiny/bulbasaur.png" class="sprite-share-link " title="Click to use/share this sprite"><img class="img-fixed img-sprite-v13" src="https://img.pokemondb.net/sprites/x-y/shiny/bulbasaur.png" alt="Bulbasaur Shiny sprite from X &amp; Y" width="120" height="120" loading="lazy"></a>						</td>
+					<td class="text-center">
+							&mdash;
+						</td>
+					<td class="text-center">
+							&mdash;
+						</td>
+					<td class="text-center">
+							&mdash;
+						</td>
+				</tr>
+	</tbody>
+	</table>
+</div>
+	<ul class="list-focus">
+		<li><a href="/sprites/bulbasaur">See all Bulbasaur sprites</a></li>
+	</ul>
+
+
+<div id="dex-locations"></div>
+<div class="grid-row">
+	<div class="grid-col span-md-12 span-lg-8">
+		<h2>Where to find Bulbasaur</h2>
+
+			<div class="resp-scroll">
+			<table class="vitals-table">
+			<tbody>
+							<tr>
+					<th><span class="igame red">Red</span><br><span class="igame blue">Blue</span></th>
+					<td><a href="/location/kanto-pallet-town">Pallet Town</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame yellow">Yellow</span></th>
+					<td><a href="/location/kanto-cerulean-city">Cerulean City</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame gold">Gold</span><br><span class="igame silver">Silver</span><br><span class="igame crystal">Crystal</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame ruby">Ruby</span><br><span class="igame sapphire">Sapphire</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame firered">FireRed</span><br><span class="igame leafgreen">LeafGreen</span></th>
+					<td><a href="/location/kanto-pallet-town">Pallet Town</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame emerald">Emerald</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame diamond">Diamond</span><br><span class="igame pearl">Pearl</span><br><span class="igame platinum">Platinum</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame heartgold">HeartGold</span><br><span class="igame soulsilver">SoulSilver</span></th>
+					<td><a href="/location/kanto-pallet-town">Pallet Town</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame black">Black</span><br><span class="igame white">White</span><br><span class="igame black-2">Black 2</span><br><span class="igame white-2">White 2</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame x">X</span><br><span class="igame y">Y</span></th>
+					<td><a href="/location/kalos-lumiose-city">Lumiose City</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame omega-ruby">Omega Ruby</span><br><span class="igame alpha-sapphire">Alpha Sapphire</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame sun">Sun</span><br><span class="igame moon">Moon</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame ultra-sun">Ultra Sun</span><br><span class="igame ultra-moon">Ultra Moon</span></th>
+					<td><a href="/location/alola-route-2">Route 2</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame lets-go-pikachu">Let's Go Pikachu</span><br><span class="igame lets-go-eevee">Let's Go Eevee</span></th>
+					<td><a href="/location/kanto-cerulean-city">Cerulean City</a>, <a href="/location/kanto-viridian-forest">Viridian Forest</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame sword">Sword</span><br><span class="igame shield">Shield</span></th>
+					<td><small>Trade/migrate from another game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame brilliant-diamond">Brilliant Diamond</span><br><span class="igame shining-pearl">Shining Pearl</span></th>
+					<td><a href="/location/sinnoh-grassland-cave">Grassland Cave</a>, <a href="/location/sinnoh-swampy-cave">Swampy Cave</a>, <a href="/location/sinnoh-riverbank-cave">Riverbank Cave</a>, <a href="/location/sinnoh-still-water-cavern">Still-Water Cavern</a>, <a href="/location/sinnoh-sunlit-cavern">Sunlit Cavern</a>, <a href="/location/sinnoh-bogsunk-cavern">Bogsunk Cavern</a></td>
+				</tr>
+							<tr>
+					<th><span class="igame legends-arceus">Legends: Arceus</span></th>
+					<td><small>Not available in this game</small></td>
+				</tr>
+							<tr>
+					<th><span class="igame scarlet">Scarlet</span><br><span class="igame violet">Violet</span></th>
+					<td><small>Location data not yet available</small></td>
+				</tr>
+						</tbody>
+			</table>
+		</div>
+		</div>
+
+	<div class="grid-col span-md-12 span-lg-4">
+		<h2>Answers to Bulbasaur questions</h2>
+					<ul class="list-blank">
+										<li><a href="/pokebase/368228/what-is-wrong-with-my-bulbasaur">What is wrong with my bulbasaur?</a></li>
+							<li><a href="/pokebase/12184/what-is-a-good-little-cup-moveset-for-bulbasaur">What is a good Little Cup moveset for Bulbasaur?</a></li>
+							<li><a href="/pokebase/431628/is-there-a-way-with-recent-game-that-can-start-with-bulbasaur">Is there a way with a recent game that I can start with Bulbasaur?</a></li>
+							<li><a href="/pokebase/352316/what-is-bulbasaurs-design-based-upon">What is Bulbasaur&#039;s design based upon?</a></li>
+							<li><a href="/pokebase/296952/who-is-better-bulbasaur-or-charmander">Who is better? Bulbasaur or Charmander?</a></li>
+							<li><a href="/pokebase/279272/charmander-bulbasaur-or-squirtle-for-a-pokemon-in-game-team">Charmander, Bulbasaur, or Squirtle for a Pokemon X in-game team?</a></li>
+							<li><a href="/pokebase/1800/anyone-where-bulbasaur-squirtle-charmander-pokemon-diamond">Does anyone know where to find a bulbasaur, squirtle, or charmander on pokemon diamond/pearl?</a></li>
+							<li><a href="/pokebase/209539/was-bulbasaur-a-pure-grass-type-in-generation-1">Was Bulbasaur a pure Grass type in generation 1?</a></li>
+							<li><a href="/pokebase/22307/where-find-bulbasaur-squirle-charmander-heart-gold-silver">Where can I find a bulbasaur, squirle, or charmander in heart gold/soul silver?</a></li>
+							<li><a href="/pokebase/40667/double-question-about-anime">Double question about anime.</a></li>
+							<li><br><a href="/pokebase/tag/bulbasaur"><em>View more questions on PokéBase &raquo;</em></a></li>
+			</ul>
+			</div>
+</div>
+
+<div id="dex-lang"></div>
+<div class="grid-row">
+			<div class="grid-col span-md-6 span-lg-4">
+			<h2>Other languages</h2>
+			<div class="resp-scroll">
+				<table class="vitals-table">
+					<tbody>
+						<tr>
+							<th>English</th>
+							<td lang="en">Bulbasaur</td>
+						</tr>
+											<tr>
+							<th>Japanese</th>
+							<td lang="ja">フシギダネ (Fushigidane)</td>
+						</tr>
+											<tr>
+							<th>German</th>
+							<td lang="de">Bisasam</td>
+						</tr>
+											<tr>
+							<th>French</th>
+							<td lang="fr">Bulbizarre</td>
+						</tr>
+											<tr>
+							<th>Italian</th>
+							<td lang="it">Bulbasaur</td>
+						</tr>
+											<tr>
+							<th>Spanish</th>
+							<td lang="es">Bulbasaur</td>
+						</tr>
+											<tr>
+							<th>Korean</th>
+							<td lang="ko">이상해씨 (isanghaessi)</td>
+						</tr>
+											<tr>
+							<th>Chinese (Simplified)</th>
+							<td lang="zh-cn">妙蛙种子</td>
+						</tr>
+											<tr>
+							<th>Chinese (Traditional)</th>
+							<td lang="zh-tw">妙蛙種子</td>
+						</tr>
+										</tbody>
+				</table>
+			</div>
+		</div>
+	
+			<div class="grid-col span-md-6 span-lg-4">
+			<h2>&nbsp;</h2>
+			<div class="resp-scroll">
+				<table class="vitals-table">
+					<tbody>
+						<tr>
+							<th>English</th>
+							<td>
+																	Seed Pokémon<br>
+															</td>
+						</tr>
+											<tr>
+							<th>Japanese</th>
+							<td lang="ja">たねポケモン</td>
+						</tr>
+											<tr>
+							<th>German</th>
+							<td lang="de">Samen-Pokémon</td>
+						</tr>
+											<tr>
+							<th>French</th>
+							<td lang="fr">Pokémon Graine</td>
+						</tr>
+											<tr>
+							<th>Italian</th>
+							<td lang="it">Pokémon Seme</td>
+						</tr>
+											<tr>
+							<th>Spanish</th>
+							<td lang="es">Pokémon Semilla</td>
+						</tr>
+											<tr>
+							<th>Korean</th>
+							<td lang="ko">씨앗포켓몬</td>
+						</tr>
+											<tr>
+							<th>Chinese (Simplified)</th>
+							<td lang="zh-cn">种子宝可梦</td>
+						</tr>
+											<tr>
+							<th>Chinese (Traditional)</th>
+							<td lang="zh-tw">種子寶可夢</td>
+						</tr>
+										</tbody>
+				</table>
+			</div>
+		</div>
+	
+			<div class="grid-col span-md-12 span-lg-4">
+				<h2><a href="/etymology">Name origin</a></h2>
+				<dl class="etymology">
+										<dt>bulb</dt>
+					<dd>a type of plant</dd>
+										<dt>-saur</dt>
+					<dd>Greek suffix meaning ‘lizard’</dd>
+									</dl>
+		</div>
+	</div>
+
+
+<nav class="entity-nav component">
+	<a rel="next" class="entity-nav-next" href="/pokedex/ivysaur">#0002 Ivysaur</a>
+</nav>
+			<div class="component text-center" style="min-height:90px"><div id="bsa-zone_1612827518798-2_123456"></div></div>	
+</main>
+
+<footer class="main-footer">
+	<div class="grid-container">
+		<a class="wrap-right" href="/about#privacy">Privacy Policy</a>
+		All content &amp; design &copy; Pokémon Database, 2008-2025.
+		Pokémon images &amp; names &copy; 1995-2025 Nintendo/Game Freak.
+	</div>
+</footer>
+
+</body>
+</html>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,7 @@
+from PoGo_rarity import EnhancedRarityScraper
+
+def test_pokemondb_integration_small_set():
+    scraper = EnhancedRarityScraper()
+    data, report = scraper.scrape_pokemondb_catch_rate(limit=2)
+    assert report.success
+    assert len(data) == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from PoGo_rarity import EnhancedRarityScraper
+
+def test_parse_catch_rate_from_fixture():
+    scraper = EnhancedRarityScraper()
+    fixture = Path(__file__).parent / "fixtures" / "pokemondb_bulbasaur.html"
+    html = fixture.read_text(encoding="utf-8")
+    catch_rate = scraper.parse_pokemondb_catch_rate(html)
+    assert catch_rate == 45

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,0 +1,7 @@
+from PoGo_rarity import EnhancedRarityScraper
+
+def test_slugify_handles_regional_forms_and_punctuation():
+    scraper = EnhancedRarityScraper()
+    assert scraper.slugify_name("Alolan Rattata") == "rattata"
+    assert scraper.slugify_name("Galarian Farfetch'd") == "farfetchd"
+    assert scraper.slugify_name("Type: Null") == "type-null"


### PR DESCRIPTION
## Summary
- avoid repeated 404s on regional Pokémon forms by normalising names before hitting PokemonDB
- add structured logging, request metrics and no-retry behaviour for 403/404 responses
- basic tests for slugification and catch-rate parsing with HTML fixtures

## Testing
- `pytest -q`
- `python PoGo_rarity.py --limit 5`

------
https://chatgpt.com/codex/tasks/task_e_68bf905fe1cc832880b61d61c4e62853