### PR TITLE
Remove duplicated Pokémon entries

### DIFF
--- a/data/pokemon_list.json
+++ b/data/pokemon_list.json
@@ -3392,20 +3392,20 @@
     "number": 795
   },
   {
+    "name": "Poipole",
+    "number": 803
+  },
+  {
+    "name": "Naganadel",
+    "number": 804
+  },
+  {
     "name": "Stakataka",
     "number": 805
   },
   {
-    "name": "Poipole",
-    "number": 806
-  },
-  {
     "name": "Blacephalon",
     "number": 806
-  },
-  {
-    "name": "Naganadel",
-    "number": 807
   },
   {
     "name": "Zeraora",
@@ -3632,20 +3632,8 @@
     "number": 862
   },
   {
-    "name": "Obstagoon",
-    "number": 862
-  },
-  {
     "name": "Perrserker",
     "number": 863
-  },
-  {
-    "name": "Perrserker",
-    "number": 863
-  },
-  {
-    "name": "Cursola",
-    "number": 864
   },
   {
     "name": "Cursola",
@@ -3656,20 +3644,8 @@
     "number": 865
   },
   {
-    "name": "Sirfetch'd",
-    "number": 865
-  },
-  {
     "name": "Mr. Rime",
     "number": 866
-  },
-  {
-    "name": "Mr. Rime",
-    "number": 866
-  },
-  {
-    "name": "Runerigus",
-    "number": 867
   },
   {
     "name": "Runerigus",


### PR DESCRIPTION
## Summary
- Remove duplicate Galarian evolution entries from `data/pokemon_list.json`
- Correct misnumbered Poipole and Naganadel entries to ensure unique Pokédex numbers

## Testing
- `python -m json.tool data/pokemon_list.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa5b119c83289567cbd218bf6f8b