### PR TITLE
docs: add comprehensive README and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# Agents & Automation
+
+## Purpose
+
+Automated agents run tests, scrape data and serve the UI. They must respect external rate limits, avoid PII, and leave the repository in a clean state.
+
+## Agent Roster
+
+| Agent | Role | Inputs | Outputs | Tools |
+|---|---|---|---|---|
+| scraper | gather rarity metrics | limit, dry_run, output_dir | CSV, logs | pokemon_rarity_cli, http_request |
+| tester | execute unit tests | none | pass/fail report | pytest |
+| linter | check markdown | file paths | warnings | markdownlint_cli |
+| ui | serve Streamlit | port | running web app | streamlit_run |
+
+## Tool Contracts
+
+```json
+{
+  "name": "pokemon_rarity_cli",
+  "input_schema": {"limit": "int?", "dry_run": "bool", "output_dir": "string?"},
+  "errors": ["EHTTP", "EIO"],
+  "timeout_sec": 600,
+  "side_effects": ["network", "filesystem"]
+}
+```
+
+```json
+{
+  "name": "pytest",
+  "input_schema": {"tests": "string?"},
+  "errors": ["EIMPORT", "EASSERT"],
+  "timeout_sec": 300,
+  "side_effects": []
+}
+```
+
+```json
+{
+  "name": "markdownlint_cli",
+  "input_schema": {"paths": "[string]"},
+  "errors": ["ELINT"],
+  "timeout_sec": 60,
+  "side_effects": []
+}
+```
+
+```json
+{
+  "name": "streamlit_run",
+  "input_schema": {"file": "string", "port": "int"},
+  "errors": ["EADDRINUSE"],
+  "timeout_sec": 60,
+  "side_effects": ["network"]
+}
+```
+
+## Prompt Contracts
+
+### System Prompt (scraper)
+
+- Be courteous: wait `1s` between outbound requests.
+- Abort on repeated `403` or `429` responses.
+- Log all request metadata.
+
+### Task Prompt Template
+
+```text
+Run `pokemon-rarity --limit {{limit}} --dry-run{{#if output_dir}} --output-dir {{output_dir}}{{/if}}` and return the resulting CSV path or error.
+```
+
+### Few-shot Example
+
+```text
+Input: limit=5
+Output: `/workspace/pokemon_rarity_analysis_enhanced.csv`
+```
+
+## Memory / RAG
+
+- Index files under `data/` and generated CSVs.
+- Chunk size: 2KB.
+- Metadata: file path, data source, timestamp.
+- Remove cached data older than 30 days and redact any tokens.
+
+## Orchestration & Handoffs
+
+- `tester` runs before `scraper` to ensure code health.
+- `scraper` writes CSV then notifies `ui` to restart.
+- On failure, agents retry up to 3 times with exponential backoff.
+- All tools must be idempotent; include a run ID in temp files.
+
+## Safety
+
+- Never store or echo PII.
+- Do not commit secrets; use environment variables for tokens.
+- Escalate to a human if external services return unexpected content.
+
+## Evaluation
+
+- Regression suite: `pytest` must pass.
+- Smoke test: `pokemon-rarity --limit 1 --dry-run` completes in <2 min.
+- Success metrics: scrape completion rate, test pass rate, mean latency.
+
+## Ops Runbook
+
+- **Deploy prompts/tools**: update `AGENTS.md` and merge to `main`.
+- **Rotate keys**: replace environment variables and restart agents.
+- **Logging**: inspect `pogorarity/pogo_debug.log` and Streamlit console.
+- **Dashboards**: TODO add metrics dashboard.
+- **Incidents**: capture logs, revert to last known good commit, notify maintainers.
+
+Refer to [README.md](README.md) for project overview and manual commands.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,142 @@
 # PoGo Rarity
+>
+> Aggregates public Pokémon GO data sources to recommend which monsters to keep or trade.
 
-Utilities for aggregating Pokémon GO rarity information.
+![tests](https://img.shields.io/badge/tests-passing-brightgreen) ![status](https://img.shields.io/badge/status-experimental-blue)
 
-## Usage
+## Overview
 
-Install the package and run the CLI:
+PoGo Rarity collects spawn and catch-rate information from multiple community datasets and websites, normalises the values and produces a single CSV with recommendations. A small Streamlit app lets you explore the results interactively.
 
-```bash
-pokemon-rarity --limit 50
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph CLI
+    A["pokemon-rarity\nCLI"]
+  end
+  subgraph Web
+    B["Streamlit UI"]
+  end
+  A --> S[Scraper]
+  S -->|HTTP| PokeDB[PokemonDB]
+  S -->|HTTP| GOHub[GO Hub]
+  S -->|HTTP| Structured[Structured JSON]
+  S -->|reads| Curated[(Curated JSON)]
+  S -->|writes| CSV[(analysis CSV)]
+  B -->|reads| CSV
 ```
 
-The `--limit` option restricts the number of Pokémon processed from
-PokemonDB, which is useful during testing.
+## Quickstart
 
+### Prerequisites
 
-## Streamlit App
+- Python ≥3.10
+- Node ≥18 (for Markdown linting)
+- Optional: Docker for deployment
 
-Run the interactive app with:
+### Setup
 
 ```bash
+git clone <repo>
+cd <repo>
+pip install -e .
+```
+
+### Run
+
+```bash
+# scrape a small sample without writing a file
+pokemon-rarity --limit 5 --dry-run
+
+# launch the Streamlit interface on http://localhost:8501
 streamlit run app.py
 ```
 
+## Configuration
+
+| Name | Type | Default | Required | Description |
+|---|---|---|---|---|
+| N/A | – | – | – | Configuration is handled via CLI flags (`--limit`, `--dry-run`, `--output-dir`). |
+
+## Commands
+
+```bash
+# run tests
+python -m pytest
+
+# lint markdown files
+npx markdownlint-cli README.md AGENTS.md
+
+# build the package
+python -m build
+```
+
+## Usage Examples
+
+```bash
+$ pokemon-rarity --limit 2 --dry-run
+INFO - Aggregating rarity data from multiple enhanced sources...
+INFO - Fetching structured spawn data...
+INFO - Attempting to scrape Pokemon Database...
+```
+
+```http
+GET / HTTP/1.1
+Host: localhost:8501
+```
+
+The above HTTP request returns the Streamlit landing page after running `streamlit run app.py`.
+
+## Deployment
+
+- **Docker**: TODO create Dockerfile.
+- **Kubernetes**: build an image and expose the Streamlit port 8501; mount output directory for CSVs.
+- Run migrations or seeds: not applicable.
+
+## Testing & QA
+
+- Run `python -m pytest` for the unit test suite.
+- Tests use fixtures under `tests/fixtures`.
+- Coverage: TODO add coverage tooling.
+
+## Observability
+
+- Request logs are written to `pogorarity/pogo_debug.log`.
+- Basic metrics (`requests`, `errors`, `latencies`) are available on the `EnhancedRarityScraper.metrics` dict.
+- Health checks: ensure the CSV exists and Streamlit responds on `/`.
+
+## Security & Privacy
+
+- No authentication built in; run behind a trusted network.
+- Scraper obeys polite delays and logs all outbound requests.
+- Do not store PII; generated CSV contains only public game data.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|---|---|---|
+| ModuleNotFoundError | Dependencies missing | `pip install -e .` |
+| HTTP 429 errors | Rate limiting by external sites | Re-run later; scraper backs off automatically |
+| CSV not generated | `--dry-run` used or path unwritable | Remove `--dry-run` or set `--output-dir` |
+| Streamlit shows blank table | CSV missing | Run scraper first |
+| Tests fail to import requests | Dependencies missing | `pip install -e .` |
+| Markdown lint fails | `markdownlint-cli` not installed | `npm install -g markdownlint-cli` |
+| Network timeouts | External sites slow | Increase `--limit` slowly or retry |
+| Permission denied writing CSV | Output directory protected | Use a writable path |
+| Streamlit port in use | Another service on 8501 | `streamlit run app.py --server.port 8502` |
+| CLI runs too long | Scraping full Pokédex | Use `--limit` during development |
+
+## Contributing
+
+1. Fork and clone the repo.
+2. Create a feature branch from `main`.
+3. Run tests and lint before committing.
+4. Submit a pull request and mention maintainers.
+
+See [AGENTS.md](AGENTS.md) for automation details.
+
+## License & Support
+
+- License: TODO
+- Support: open an issue or contact `support@example.com`


### PR DESCRIPTION
## Summary
- document architecture, setup, and ops in a new comprehensive README
- add AGENTS.md with instructions for automation and tooling

## Testing
- `python -m pytest -q`
- `markdownlint README.md AGENTS.md --disable MD013`


------
https://chatgpt.com/codex/tasks/task_e_68c03596ed5083288b2c7a7441b9ff88