### PR TITLE
Unify rarity sources via RarityRecord schema

### DIFF
--- a/pogorarity/__init__.py
+++ b/pogorarity/__init__.py
@@ -1,10 +1,25 @@
 """pogorarity package."""
 
 from .scraper import EnhancedRarityScraper
-from .models import PokemonRarity, DataSourceReport
+from .models import PokemonRarity, DataSourceReport, RarityRecord
+from .adapters import (
+    get_go_hub_records,
+    get_pokemondb_records,
+    get_structured_spawn_records,
+    parse_go_hub,
+    parse_pokemondb_page,
+    parse_structured_spawn_data,
+)
 
 __all__ = [
     "EnhancedRarityScraper",
     "PokemonRarity",
     "DataSourceReport",
+    "RarityRecord",
+    "get_go_hub_records",
+    "get_pokemondb_records",
+    "get_structured_spawn_records",
+    "parse_go_hub",
+    "parse_pokemondb_page",
+    "parse_structured_spawn_data",
 ]

--- a/pogorarity/adapters.py
+++ b/pogorarity/adapters.py
@@ -1,0 +1,179 @@
+import csv
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from .models import RarityRecord
+
+RATE_LIMIT = 1.0
+RETRIES = 3
+
+
+def fetch_with_cache(url: str, cache_file: Path, session: Optional[requests.Session] = None) -> str:
+    """Fetch a URL respecting ETag/Last-Modified and local cache."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    meta_file = cache_file.with_suffix(cache_file.suffix + ".meta")
+    headers = {}
+    if meta_file.exists():
+        try:
+            meta = json.loads(meta_file.read_text())
+            if meta.get("etag"):
+                headers["If-None-Match"] = meta["etag"]
+            if meta.get("last_modified"):
+                headers["If-Modified-Since"] = meta["last_modified"]
+        except Exception:
+            pass
+    sess = session or requests.Session()
+    for attempt in range(RETRIES):
+        time.sleep(RATE_LIMIT)
+        resp = sess.get(url, headers=headers)
+        if resp.status_code == 304 and cache_file.exists():
+            return cache_file.read_text()
+        try:
+            resp.raise_for_status()
+        except requests.RequestException:
+            if attempt == RETRIES - 1:
+                raise
+            time.sleep(RATE_LIMIT * (2 ** attempt))
+            continue
+        cache_file.write_text(resp.text)
+        meta = {
+            "etag": resp.headers.get("ETag"),
+            "last_modified": resp.headers.get("Last-Modified"),
+        }
+        meta_file.write_text(json.dumps(meta))
+        return resp.text
+    raise RuntimeError("unreachable")
+
+
+def save_records(records: List[RarityRecord], base_path: Path) -> None:
+    """Save records to JSON and CSV files."""
+    base_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path = base_path.with_suffix(".json")
+    csv_path = base_path.with_suffix(".csv")
+    data = [r.dict() for r in records]
+    json_path.write_text(json.dumps(data, default=str))
+    if data:
+        with csv_path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=list(data[0].keys()))
+            writer.writeheader()
+            writer.writerows(data)
+    else:
+        csv_path.write_text("")
+
+
+RARITY_MAP = {
+    "common": 8.0,
+    "uncommon": 5.0,
+    "rare": 2.0,
+    "legendary": 0.5,
+}
+
+
+def parse_go_hub(html: str, timestamp: Optional[datetime] = None) -> List[RarityRecord]:
+    """Parse simplified Pokemon GO Hub HTML into RarityRecord objects."""
+    soup = BeautifulSoup(html, "html.parser")
+    records: List[RarityRecord] = []
+    ts = timestamp or datetime.utcnow()
+    for row in soup.select("tr"):
+        cells = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cells) >= 2:
+            name, rarity_text = cells[0], cells[1].lower()
+            score = RARITY_MAP.get(rarity_text, 5.0)
+            records.append(
+                RarityRecord(
+                    pokemon_name=name,
+                    rarity=score,
+                    source="Pokemon GO Hub",
+                    confidence=0.6,
+                    timestamp=ts,
+                )
+            )
+    return records
+
+
+def parse_structured_spawn_data(text: str, timestamp: Optional[datetime] = None) -> List[RarityRecord]:
+    data = json.loads(text)
+    records: List[RarityRecord] = []
+    ts = timestamp or datetime.utcnow()
+    for entry in data.get("pokemon", []):
+        name = entry.get("name")
+        spawn = entry.get("spawn_chance")
+        if name and spawn is not None:
+            rarity = min(10.0, max(0.0, float(spawn) / 2.0))
+            records.append(
+                RarityRecord(
+                    pokemon_name=name,
+                    rarity=rarity,
+                    source="Structured Spawn Data",
+                    confidence=0.8,
+                    timestamp=ts,
+                )
+            )
+    return records
+
+
+def slugify_name(name: str) -> str:
+    slug = name.lower().replace("♀", "-f").replace("♂", "-m")
+    slug = slug.replace(":", "").replace("'", "").replace(".", "")
+    return slug.replace("é", "e").replace(" ", "-")
+
+
+def parse_pokemondb_page(name: str, html: str, timestamp: Optional[datetime] = None) -> Optional[RarityRecord]:
+    soup = BeautifulSoup(html, "html.parser")
+    th = soup.find("th", string=lambda s: s and "Catch rate" in s)
+    if not th:
+        return None
+    td = th.find_next("td")
+    if not td:
+        return None
+    digits = ''.join(ch for ch in td.get_text() if ch.isdigit())
+    if not digits:
+        return None
+    catch_rate = int(digits)
+    rarity = min(10.0, catch_rate / 25.5)
+    return RarityRecord(
+        pokemon_name=name,
+        rarity=rarity,
+        source="PokemonDB Catch Rate",
+        confidence=0.9,
+        timestamp=timestamp or datetime.utcnow(),
+    )
+
+
+def get_structured_spawn_records(cache_dir: str = "data") -> List[RarityRecord]:
+    url = "https://raw.githubusercontent.com/Biuni/PokemonGO-Pokedex/master/pokedex.json"
+    cache_file = Path(cache_dir) / "structured_spawn_raw.json"
+    text = fetch_with_cache(url, cache_file)
+    records = parse_structured_spawn_data(text)
+    save_records(records, Path(cache_dir) / "structured_spawn_records")
+    return records
+
+
+def get_go_hub_records(cache_dir: str = "data") -> List[RarityRecord]:
+    url = "https://db.pokemongohub.net/"
+    cache_file = Path(cache_dir) / "go_hub_raw.html"
+    html = fetch_with_cache(url, cache_file)
+    records = parse_go_hub(html)
+    save_records(records, Path(cache_dir) / "go_hub_records")
+    return records
+
+
+def get_pokemondb_records(names: List[str], cache_dir: str = "data") -> List[RarityRecord]:
+    records: List[RarityRecord] = []
+    session = requests.Session()
+    for name in names:
+        slug = slugify_name(name)
+        url = f"https://pokemondb.net/pokedex/{slug}"
+        cache_file = Path(cache_dir) / f"pokemondb_{slug}.html"
+        html = fetch_with_cache(url, cache_file, session=session)
+        rec = parse_pokemondb_page(name, html)
+        if rec:
+            records.append(rec)
+    save_records(records, Path(cache_dir) / "pokemondb_records")
+    return records

--- a/pogorarity/models.py
+++ b/pogorarity/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
@@ -22,4 +23,14 @@ class DataSourceReport(BaseModel):
     pokemon_count: int
     success: bool
     error_message: Optional[str] = None
+
+
+class RarityRecord(BaseModel):
+    """Normalized rarity information for a single Pokémon from one source."""
+
+    pokemon_name: str
+    rarity: float
+    source: str
+    confidence: float
+    timestamp: datetime
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+import json
+
+from pogorarity.adapters import (
+    parse_go_hub,
+    parse_pokemondb_page,
+    parse_structured_spawn_data,
+)
+
+
+def test_parse_structured_spawn_data():
+    sample = {
+        "pokemon": [
+            {"name": "Bulbasaur", "spawn_chance": 0.69},
+            {"name": "Mewtwo", "spawn_chance": 0.0005},
+        ]
+    }
+    records = parse_structured_spawn_data(json.dumps(sample), timestamp=datetime(2024, 1, 1))
+    assert records[0].pokemon_name == "Bulbasaur"
+    assert records[0].source == "Structured Spawn Data"
+
+
+def test_parse_pokemondb_page():
+    html = """<table><tr><th>Catch rate</th><td>45 (test)</td></tr></table>"""
+    rec = parse_pokemondb_page("Bulbasaur", html, timestamp=datetime(2024, 1, 1))
+    assert rec is not None
+    assert rec.pokemon_name == "Bulbasaur"
+    assert rec.source == "PokemonDB Catch Rate"
+
+
+def test_parse_go_hub():
+    html = """<table><tr><td>Bulbasaur</td><td>Common</td></tr></table>"""
+    records = parse_go_hub(html, timestamp=datetime(2024, 1, 1))
+    assert records and records[0].rarity == 8.0
+    assert records[0].source == "Pokemon GO Hub"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,8 @@
 import pytest
+from datetime import datetime
 from pydantic import ValidationError
 
-from pogorarity.models import DataSourceReport, PokemonRarity
+from pogorarity.models import DataSourceReport, PokemonRarity, RarityRecord
 
 
 def test_pokemon_rarity_validation():
@@ -31,3 +32,23 @@ def test_pokemon_rarity_validation():
 def test_datasource_report_validation():
     with pytest.raises(ValidationError):
         DataSourceReport(source_name="site", pokemon_count="ten", success=True)
+
+
+def test_rarity_record_validation():
+    rec = RarityRecord(
+        pokemon_name="Bulbasaur",
+        rarity=1.0,
+        source="test",
+        confidence=0.9,
+        timestamp=datetime.utcnow(),
+    )
+    assert rec.source == "test"
+
+    with pytest.raises(ValidationError):
+        RarityRecord(
+            pokemon_name="Bulbasaur",
+            rarity="bad",
+            source="test",
+            confidence=0.9,
+            timestamp=datetime.utcnow(),
+        )


### PR DESCRIPTION
## Summary
- add `RarityRecord` Pydantic model for normalized rarity entries
- implement adapters with caching & rate-limited fetches for Go Hub, PokémonDB, and structured spawn data
- test schema validation and adapter parsing with sample fixtures

## Testing
- `pytest -q`
- `python -m pogorarity.cli --limit 1 --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68c03e83efb08328a5bf016683df7b65