### PR TITLE
Fix inverted rarity band classification

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,11 +32,32 @@ def generation_from_number(num: int) -> int:
 
 
 def rarity_band(score: float) -> str:
-    if score < 1:
+    """Map a numeric rarity score to a human-friendly rarity band.
+
+    The underlying data uses higher scores to indicate more common
+    Pokémon. Previously this function treated lower scores as more
+    common, which inverted the rarity bands (e.g. ubiquitous Pokémon
+    like Caterpie were marked "Very Rare"). The thresholds below now
+    reflect the correct ordering where larger scores correspond to more
+    common Pokémon.
+
+    Parameters
+    ----------
+    score:
+        A floating point rarity score from 0 (rarest) to 10 (most
+        common).
+
+    Returns
+    -------
+    str
+        One of "Very Rare", "Rare", "Uncommon", or "Common".
+    """
+
+    if score >= 3:
         return "Common"
-    if score < 2:
+    if score >= 2:
         return "Uncommon"
-    if score < 3:
+    if score >= 1:
         return "Rare"
     return "Very Rare"
 

--- a/tests/test_rarity_band.py
+++ b/tests/test_rarity_band.py
@@ -1,0 +1,9 @@
+from app import rarity_band
+
+
+def test_rarity_band_ordering():
+    """Higher scores should correspond to more common bands."""
+    assert rarity_band(0.5) == "Very Rare"
+    assert rarity_band(1.5) == "Rare"
+    assert rarity_band(2.5) == "Uncommon"
+    assert rarity_band(5.0) == "Common"


### PR DESCRIPTION
## Summary
- correct rarity band mapping so higher scores map to more common bands
- add unit test covering rarity band ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0528347488328bcab0ad0f4dc59e8