### PR TITLE
Load rarity inference rules from external config

### DIFF
--- a/data/infer_missing_rarity_rules.json
+++ b/data/infer_missing_rarity_rules.json
@@ -1,0 +1,27 @@
+{
+  "pseudo_legendaries": {
+    "description": "Pseudo-legendary Pokémon that are rare despite not being legendary",
+    "pokemon": ["Dratini", "Larvitar", "Bagon", "Beldum", "Gible", "Axew", "Deino", "Goomy", "Jangmo-o", "Dreepy"],
+    "score": 1.5
+  },
+  "starters": {
+    "description": "Starter Pokémon from each generation are relatively common",
+    "pokemon": [
+      "Bulbasaur", "Charmander", "Squirtle", "Chikorita", "Cyndaquil", "Totodile",
+      "Treecko", "Torchic", "Mudkip", "Turtwig", "Chimchar", "Piplup",
+      "Snivy", "Tepig", "Oshawott", "Chespin", "Fennekin", "Froakie",
+      "Rowlet", "Litten", "Popplio", "Grookey", "Scorbunny", "Sobble"
+    ],
+    "score": 6.0
+  },
+  "very_common": {
+    "description": "Early-route Pokémon that appear very frequently",
+    "pokemon": ["Pidgey", "Rattata", "Caterpie", "Weedle", "Bidoof", "Patrat", "Lillipup"],
+    "score": 8.5
+  },
+  "regional_forms": {
+    "description": "Regional form Pokémon that include the region name",
+    "regions": ["Alolan", "Galarian", "Hisuian", "Paldean"],
+    "score": 4.0
+  }
+}

--- a/tests/test_infer_missing_rarity.py
+++ b/tests/test_infer_missing_rarity.py
@@ -1,0 +1,17 @@
+import pytest
+from pogorarity import EnhancedRarityScraper
+
+
+@pytest.mark.parametrize(
+    "name,number,spawn_type,expected",
+    [
+        ("Dratini", 147, "wild", 1.5),  # pseudo-legendary rule
+        ("Bulbasaur", 1, "wild", 6.0),  # starter rule
+        ("Pidgey", 16, "wild", 8.5),  # very common rule
+        ("Alolan Vulpix", 37, "wild", 4.0),  # regional form rule
+        ("Zigzagoon", 263, "wild", 5.0),  # generation-based default
+    ],
+)
+def test_infer_missing_rarity(name, number, spawn_type, expected):
+    scraper = EnhancedRarityScraper()
+    assert scraper.infer_missing_rarity(name, number, spawn_type) == expected


### PR DESCRIPTION
## Summary
- move rarity inference lists into `data/infer_missing_rarity_rules.json` with descriptions
- load rules from config in `EnhancedRarityScraper.infer_missing_rarity`
- add unit tests for rarity inference rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c069876ffc8328b504259d71f63734