### PR TITLE
Align trading recommendations with rarity bands

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,13 @@ def rarity_band(score: float) -> str:
     common, which inverted the rarity bands (e.g. ubiquitous Pokémon
     like Caterpie were marked "Very Rare"). The thresholds below now
     reflect the correct ordering where larger scores correspond to more
-    common Pokémon.
+    common Pokémon.  The score ranges shared with
+    :func:`pogorarity.aggregator.get_trading_recommendation` are:
+
+    - ``score < 2`` -> "Very Rare"
+    - ``2 <= score < 4`` -> "Rare"
+    - ``4 <= score < 7`` -> "Uncommon"
+    - ``score >= 7`` -> "Common"
 
     Parameters
     ----------
@@ -53,11 +59,11 @@ def rarity_band(score: float) -> str:
         One of "Very Rare", "Rare", "Uncommon", or "Common".
     """
 
-    if score >= 3:
+    if score >= 7:
         return "Common"
-    if score >= 2:
+    if score >= 4:
         return "Uncommon"
-    if score >= 1:
+    if score >= 2:
         return "Rare"
     return "Very Rare"
 

--- a/pogorarity/aggregator.py
+++ b/pogorarity/aggregator.py
@@ -90,15 +90,28 @@ def categorize_pokemon_spawn_type(pokemon_name: str, pokemon_number: int) -> str
 
 
 def get_trading_recommendation(score: float, spawn_type: str) -> str:
+    """Return a trading recommendation based on rarity score and spawn type.
+
+    Scores are on a 0--10 scale where higher numbers represent more common
+    Pokémon.  The same numeric ranges are used by :func:`app.rarity_band` to
+    display rarity bands.  The ranges are:
+
+    - ``score < 4``  -> "Should Always Trade"
+    - ``4 <= score < 7`` -> "Depends on Circumstances"
+    - ``score >= 7`` -> "Safe to Transfer"
+
+    Special spawn types take precedence over the numeric score.
+    """
+
     if spawn_type == "legendary":
         return "Never Transfer (Legendary)"
     if spawn_type == "event-only":
         return "Never Transfer (Event Only)"
     if spawn_type == "evolution-only":
         return "Evaluate for Evolution"
-    if score >= 6:
+    if score >= 7:
         return "Safe to Transfer"
-    if score >= 3:
+    if score >= 4:
         return "Depends on Circumstances"
     return "Should Always Trade"
 

--- a/tests/test_rarity_band.py
+++ b/tests/test_rarity_band.py
@@ -3,7 +3,14 @@ from app import rarity_band
 
 def test_rarity_band_ordering():
     """Higher scores should correspond to more common bands."""
-    assert rarity_band(0.5) == "Very Rare"
-    assert rarity_band(1.5) == "Rare"
-    assert rarity_band(2.5) == "Uncommon"
-    assert rarity_band(5.0) == "Common"
+    assert rarity_band(1.0) == "Very Rare"
+    assert rarity_band(3.0) == "Rare"
+    assert rarity_band(5.0) == "Uncommon"
+    assert rarity_band(8.0) == "Common"
+
+
+def test_rarity_band_boundaries():
+    """Boundary scores should fall into the correct bands."""
+    assert rarity_band(2.0) == "Rare"
+    assert rarity_band(4.0) == "Uncommon"
+    assert rarity_band(7.0) == "Common"

--- a/tests/test_trading_recommendation.py
+++ b/tests/test_trading_recommendation.py
@@ -1,0 +1,16 @@
+from pogorarity import get_trading_recommendation
+
+
+def test_trading_recommendation_special_cases():
+    assert get_trading_recommendation(5.0, "legendary") == "Never Transfer (Legendary)"
+    assert get_trading_recommendation(5.0, "event-only") == "Never Transfer (Event Only)"
+    assert get_trading_recommendation(5.0, "evolution-only") == "Evaluate for Evolution"
+
+
+def test_trading_recommendation_ranges():
+    assert get_trading_recommendation(1.0, "wild") == "Should Always Trade"
+    assert get_trading_recommendation(3.5, "wild") == "Should Always Trade"
+    assert get_trading_recommendation(4.0, "wild") == "Depends on Circumstances"
+    assert get_trading_recommendation(6.5, "wild") == "Depends on Circumstances"
+    assert get_trading_recommendation(7.0, "wild") == "Safe to Transfer"
+    assert get_trading_recommendation(9.5, "wild") == "Safe to Transfer"


### PR DESCRIPTION
## Summary
- Share common score ranges between rarity bands and trading recommendations
- Document shared ranges and update logic in `rarity_band` and `get_trading_recommendation`
- Expand rarity band tests and add coverage for trading recommendations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0743e0b488328bf4f3be82fa41e83