### PR TITLE
Parameterize scraper score ranges with logging

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Dict, Iterable, Tuple, List
+
+logger = logging.getLogger(__name__)
+
+
+def _scale_records(
+    records: Iterable[Tuple[str, float]],
+    expected_min: float,
+    expected_max: float,
+    auto_scale: bool,
+) -> Dict[str, float]:
+    records = list(records)
+    if not records:
+        return {}
+    values = [v for _, v in records]
+    observed_min = min(values)
+    observed_max = max(values)
+    range_min, range_max = expected_min, expected_max
+    if observed_min < expected_min or observed_max > expected_max:
+        logger.warning(
+            "Observed values outside expected range [%s, %s]; min=%s max=%s",
+            expected_min,
+            expected_max,
+            observed_min,
+            observed_max,
+        )
+        if auto_scale:
+            range_min = min(observed_min, range_min)
+            range_max = max(observed_max, range_max)
+    if range_max == range_min:
+        return {name: 0.0 for name, _ in records}
+    scaled: Dict[str, float] = {}
+    for name, value in records:
+        score = 10.0 * (value - range_min) / (range_max - range_min)
+        score = max(0.0, min(10.0, score))
+        scaled[name] = score
+    return scaled
+
+
+def scrape_structured_spawn_data(
+    entries: Iterable[Dict[str, float]],
+    *,
+    expected_min: float = 0.0,
+    expected_max: float = 20.0,
+    auto_scale: bool = False,
+) -> Dict[str, float]:
+    """Compute scores from structured spawn data entries."""
+    records = []
+    for entry in entries:
+        name = entry.get("name")
+        spawn_chance = entry.get("spawn_chance")
+        if name is None or spawn_chance is None:
+            continue
+        try:
+            records.append((name, float(spawn_chance)))
+        except (TypeError, ValueError):
+            continue
+    return _scale_records(records, expected_min, expected_max, auto_scale)
+
+
+def scrape_pokemondb_catch_rate(
+    catch_rates: Dict[str, float],
+    *,
+    expected_min: float = 0.0,
+    expected_max: float = 255.0,
+    auto_scale: bool = False,
+) -> Dict[str, float]:
+    """Compute scores from PokemonDB catch rate data."""
+    records = []
+    for name, rate in catch_rates.items():
+        try:
+            records.append((name, float(rate)))
+        except (TypeError, ValueError):
+            continue
+    return _scale_records(records, expected_min, expected_max, auto_scale)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,42 @@
+import logging
+import pytest
+
+from scraper import scrape_structured_spawn_data, scrape_pokemondb_catch_rate
+
+
+def test_structured_spawn_out_of_range(caplog):
+    data = [
+        {"name": "Pikachu", "spawn_chance": 5},
+        {"name": "Mewtwo", "spawn_chance": 25},
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = scrape_structured_spawn_data(
+            data, expected_min=0, expected_max=20, auto_scale=False
+        )
+    assert "outside expected range" in caplog.text
+    assert result["Pikachu"] == pytest.approx(2.5)
+    assert result["Mewtwo"] == 10.0
+
+
+def test_structured_spawn_auto_scale(caplog):
+    data = [
+        {"name": "Pikachu", "spawn_chance": 5},
+        {"name": "Mewtwo", "spawn_chance": 25},
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = scrape_structured_spawn_data(
+            data, expected_min=0, expected_max=20, auto_scale=True
+        )
+    assert "outside expected range" in caplog.text
+    assert result["Pikachu"] == pytest.approx(2.0)
+    assert result["Mewtwo"] == pytest.approx(10.0)
+
+
+def test_pokemondb_out_of_range(caplog):
+    data = {"Pidgey": 300}
+    with caplog.at_level(logging.WARNING):
+        result = scrape_pokemondb_catch_rate(
+            data, expected_min=0, expected_max=255, auto_scale=False
+        )
+    assert "outside expected range" in caplog.text
+    assert result["Pidgey"] == 10.0


### PR DESCRIPTION
## Summary
- add reusable scaling helper for scraper data
- support configurable min/max ranges and optional auto scaling
- test out-of-range logging and scaling behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c07527dcb48328b808cf90abacc475