### PR TITLE
docs: document scoring model and inference rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,35 @@ flowchart LR
   B -->|reads| CSV
 ```
 
+## Scoring Model
+
+The pipeline aggregates rarity information from three sources:
+
+- Structured Spawn Data
+- Enhanced Curated Data
+- PokemonDB Catch Rate
+
+Each source's raw spawn chance or catch rate is normalised onto a 0–10
+scale where 0 denotes the rarest encounters and 10 the most common. The
+scores are combined using a weighted average:
+
+- Structured Spawn Data – weight 1.0
+- Enhanced Curated Data – weight 1.0
+- PokemonDB Catch Rate – weight 2.0
+
+The resulting `Average_Rarity_Score` feeds two threshold sets:
+
+- Rarity bands: `<2` Very Rare, `2–4` Rare, `4–7` Uncommon, `≥7` Common.
+- Trading recommendations: score `<4` → "Should Always Trade", `4–7` →
+  "Depends on Circumstances", `≥7` → "Safe to Transfer". Legendary,
+  event-only, and evolution-only species override these thresholds with
+  conservative recommendations.
+
+When no source provides a score, inference rules in
+[data/infer_missing_rarity_rules.json](data/infer_missing_rarity_rules.json)
+assign default values for specific groups such as pseudo-legendaries or
+starters.
+
 ## Quickstart
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- explain data sources, weighting, and recommendation thresholds in new Scoring Model section
- link inference rules configuration file

## Testing
- `npx markdownlint-cli README.md AGENTS.md` *(fails: line-length warnings)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0766b307483288616153da4ac57c6