### PR TITLE
Add requirements and license files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PoGo Rarity contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -175,5 +175,5 @@ See [AGENTS.md](AGENTS.md) for automation details.
 
 ## License & Support
 
-- License: TODO
+- License: [MIT](LICENSE)
 - Support: open an issue or contact `support@example.com`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests==2.32.5
+pandas==2.3.2
+beautifulsoup4==4.13.5
+pydantic==2.11.7
+fastapi==0.116.1
+streamlit==1.49.1


### PR DESCRIPTION
## Summary
- add explicit requirements.txt for core dependencies
- include MIT license and link it from the README

## Testing
- `npx --yes markdownlint-cli README.md AGENTS.md` *(fails: line length warnings)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c079f09fd88328a283cfef66f0e04c