### PR TITLE
Add PokeAPI capture rate source

### DIFF
--- a/pogorarity/aggregator.py
+++ b/pogorarity/aggregator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from .models import DataSourceReport, PokemonRarity
-from .sources import curated_spawn, pokemondb, structured_spawn
+from .sources import curated_spawn, pokemondb, structured_spawn, pokeapi
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +12,7 @@ SOURCE_WEIGHTS = {
     "Structured Spawn Data": 1.0,
     "Enhanced Curated Data": 1.0,
     "PokemonDB Catch Rate": 2.0,
+    "PokeAPI Capture Rate": 2.0,
 }
 
 RULES_PATH = Path(__file__).resolve().parent.parent / "data" / "infer_missing_rarity_rules.json"
@@ -161,11 +162,15 @@ def aggregate_data(
     pokemondb_data, pokemondb_report = pokemondb.scrape_catch_rate(
         limit=limit, metrics=metrics
     )
+    pokeapi_data, pokeapi_report = pokeapi.scrape_capture_rate(
+        limit=limit, metrics=metrics
+    )
 
     sources = {
         "Structured Spawn Data": structured_data,
         "Enhanced Curated Data": curated_data,
         "PokemonDB Catch Rate": pokemondb_data,
+        "PokeAPI Capture Rate": pokeapi_data,
     }
 
     results: List[PokemonRarity] = []
@@ -200,5 +205,5 @@ def aggregate_data(
                 spawn_type=spawn_type,
             )
         )
-    reports = [structured_report, curated_report, pokemondb_report]
+    reports = [structured_report, curated_report, pokemondb_report, pokeapi_report]
     return results, reports

--- a/pogorarity/sources/pokeapi.py
+++ b/pogorarity/sources/pokeapi.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from ..helpers import safe_request
+from ..models import DataSourceReport
+
+logger = logging.getLogger(__name__)
+
+
+def scrape_capture_rate(
+    limit: Optional[int] = None,
+    session: Optional[requests.Session] = None,
+    metrics: Optional[Dict[str, float]] = None,
+) -> Tuple[Dict[str, float], DataSourceReport]:
+    """Fetch capture rates from PokeAPI and normalize to 0-10 scale."""
+    logger.info("Attempting to scrape PokeAPI...")
+    rarity_data: Dict[str, float] = {}
+    sess = session or requests.Session()
+    try:
+        from ..aggregator import get_comprehensive_pokemon_list
+
+        pokemon_list = get_comprehensive_pokemon_list()
+        if limit is not None:
+            pokemon_list = pokemon_list[:limit]
+        for name, number in pokemon_list:
+            url = f"https://pokeapi.co/api/v2/pokemon-species/{number}"
+            try:
+                response = safe_request(url, session=sess, metrics=metrics)
+                data = response.json()
+                capture_rate = data.get("capture_rate")
+                if isinstance(capture_rate, (int, float)):
+                    score = min(10.0, capture_rate / 25.5)
+                    rarity_data[name] = score
+            except Exception:
+                continue
+        report = DataSourceReport(
+            source_name="PokeAPI Capture Rate",
+            pokemon_count=len(rarity_data),
+            success=True,
+        )
+    except Exception as e:
+        logger.error("PokeAPI scraping failed: %s", e)
+        report = DataSourceReport(
+            source_name="PokeAPI Capture Rate",
+            pokemon_count=0,
+            success=False,
+            error_message=str(e),
+        )
+    return rarity_data, report

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,16 @@ import pytest
 
 from pogorarity.aggregator import aggregate_data
 from pogorarity.models import DataSourceReport
-from pogorarity.sources import curated_spawn, pokemondb, structured_spawn
+from pogorarity.sources import curated_spawn, pokemondb, structured_spawn, pokeapi
 
 def test_pokemondb_integration_small_set():
     data, report = pokemondb.scrape_catch_rate(limit=2)
+    assert report.success
+    assert len(data) == 2
+
+
+def test_pokeapi_integration_small_set():
+    data, report = pokeapi.scrape_capture_rate(limit=2)
     assert report.success
     assert len(data) == 2
 
@@ -34,10 +40,15 @@ def test_weighted_aggregation(monkeypatch):
         return ({'Bulbasaur': 6.0}, DataSourceReport(
             source_name='PokemonDB Catch Rate', pokemon_count=1, success=True))
 
+    def fake_pokeapi(limit=None, session=None, metrics=None):
+        return ({'Bulbasaur': 8.0}, DataSourceReport(
+            source_name='PokeAPI Capture Rate', pokemon_count=1, success=True))
+
     monkeypatch.setattr(structured_spawn, 'scrape', lambda metrics=None: fake_structured())
     monkeypatch.setattr(curated_spawn, 'get_data', lambda: fake_curated())
     monkeypatch.setattr(pokemondb, 'scrape_catch_rate', lambda limit=None, session=None, metrics=None: fake_pokemondb())
+    monkeypatch.setattr(pokeapi, 'scrape_capture_rate', lambda limit=None, session=None, metrics=None: fake_pokeapi())
 
     results, _ = aggregate_data(limit=1)
     assert len(results) == 1
-    assert results[0].average_score == pytest.approx(4.5)
+    assert results[0].average_score == pytest.approx(5.6666667)

--- a/tests/test_pokeapi.py
+++ b/tests/test_pokeapi.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pogorarity.sources import pokeapi
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_pokeapi_normalization(monkeypatch):
+    monkeypatch.setattr(
+        "pogorarity.aggregator.get_comprehensive_pokemon_list",
+        lambda: [("Bulbasaur", 1)],
+    )
+    monkeypatch.setattr(
+        pokeapi, "safe_request", lambda url, session=None, metrics=None: DummyResponse({"capture_rate": 300})
+    )
+
+    data, report = pokeapi.scrape_capture_rate(limit=1)
+    assert report.success
+    assert data["Bulbasaur"] == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
- Add PokeAPI capture rate scraper with normalization to 0-10 scale
- Incorporate PokeAPI data into aggregator with weighted averaging
- Test PokeAPI integration and normalization of capture rates

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c08024995c8328a1fa102cfd6a3fad