### PR TITLE
Add Silph Road spawn tier source

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ flowchart LR
 
 ## Scoring Model
 
-The pipeline aggregates rarity information from three sources:
+The pipeline aggregates rarity information from five sources:
 
 - Structured Spawn Data
 - Enhanced Curated Data
 - PokemonDB Catch Rate
+- PokeAPI Capture Rate
+- Silph Road Spawn Tier (community reported)
 
 Each source's raw spawn chance or catch rate is normalised onto a 0–10
 scale where 0 denotes the rarest encounters and 10 the most common. The
@@ -44,6 +46,8 @@ scores are combined using a weighted average:
 - Structured Spawn Data – weight 1.0
 - Enhanced Curated Data – weight 1.0
 - PokemonDB Catch Rate – weight 2.0
+- PokeAPI Capture Rate – weight 2.0
+- Silph Road Spawn Tier – weight 0.5
 
 The resulting `Average_Rarity_Score` feeds two threshold sets:
 
@@ -57,6 +61,10 @@ When no source provides a score, inference rules in
 [data/infer_missing_rarity_rules.json](data/infer_missing_rarity_rules.json)
 assign default values for specific groups such as pseudo-legendaries or
 starters.
+
+> **Note**: Silph Road spawn tier data is crowdsourced and may skew toward
+> regions with more active contributors, so regional availability is not
+> guaranteed.
 
 ## Quickstart
 

--- a/pogorarity/aggregator.py
+++ b/pogorarity/aggregator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from .models import DataSourceReport, PokemonRarity
-from .sources import curated_spawn, pokemondb, structured_spawn, pokeapi
+from .sources import curated_spawn, pokemondb, structured_spawn, pokeapi, silph_road
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ SOURCE_WEIGHTS = {
     "Enhanced Curated Data": 1.0,
     "PokemonDB Catch Rate": 2.0,
     "PokeAPI Capture Rate": 2.0,
+    "Silph Road Spawn Tier": 0.5,
 }
 
 RULES_PATH = Path(__file__).resolve().parent.parent / "data" / "infer_missing_rarity_rules.json"
@@ -165,12 +166,14 @@ def aggregate_data(
     pokeapi_data, pokeapi_report = pokeapi.scrape_capture_rate(
         limit=limit, metrics=metrics
     )
+    silph_data, silph_report = silph_road.scrape_spawn_tiers(metrics=metrics)
 
     sources = {
         "Structured Spawn Data": structured_data,
         "Enhanced Curated Data": curated_data,
         "PokemonDB Catch Rate": pokemondb_data,
         "PokeAPI Capture Rate": pokeapi_data,
+        "Silph Road Spawn Tier": silph_data,
     }
 
     results: List[PokemonRarity] = []
@@ -205,5 +208,11 @@ def aggregate_data(
                 spawn_type=spawn_type,
             )
         )
-    reports = [structured_report, curated_report, pokemondb_report, pokeapi_report]
+    reports = [
+        structured_report,
+        curated_report,
+        pokemondb_report,
+        pokeapi_report,
+        silph_report,
+    ]
     return results, reports

--- a/pogorarity/sources/silph_road.py
+++ b/pogorarity/sources/silph_road.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from ..helpers import safe_request
+from ..models import DataSourceReport
+
+logger = logging.getLogger(__name__)
+
+# Mapping from Silph Road spawn tiers to 0–10 rarity scores
+SILPH_ROAD_TIER_MAPPING: Dict[int, float] = {
+    1: 9.0,  # very common spawns
+    2: 7.0,
+    3: 5.0,
+    4: 3.0,
+    5: 1.0,  # extremely rare spawns
+}
+
+# Public dataset of community reported spawn tiers
+SILPH_ROAD_TIER_URL = (
+    "https://raw.githubusercontent.com/TheSilphRoad/pogodata/master/spawn-tiers.json"
+)
+
+
+def scrape_spawn_tiers(
+    session: Optional[requests.Session] = None,
+    metrics: Optional[Dict[str, float]] = None,
+) -> Tuple[Dict[str, float], DataSourceReport]:
+    """Fetch Silph Road spawn tiers and convert to rarity scores."""
+    logger.info("Fetching Silph Road spawn tier data...")
+    rarity_data: Dict[str, float] = {}
+    sess = session or requests.Session()
+    try:
+        response = safe_request(SILPH_ROAD_TIER_URL, session=sess, metrics=metrics)
+        data = response.json()
+        # Data may be a list of entries or mapping name->tier
+        if isinstance(data, dict):
+            entries = [
+                {"name": name, "tier": tier}
+                for name, tier in data.items()
+            ]
+        elif isinstance(data, list):
+            entries = data
+        else:
+            entries = []
+        for entry in entries:
+            name = entry.get("name") or entry.get("pokemon")
+            tier = entry.get("tier") or entry.get("spawn_tier") or entry.get("spawnTier")
+            if isinstance(tier, str):
+                try:
+                    tier = int(tier)
+                except ValueError:
+                    continue
+            if name and isinstance(tier, int) and tier in SILPH_ROAD_TIER_MAPPING:
+                rarity_data[name] = SILPH_ROAD_TIER_MAPPING[tier]
+        report = DataSourceReport(
+            source_name="Silph Road Spawn Tier",
+            pokemon_count=len(rarity_data),
+            success=len(rarity_data) > 0,
+        )
+        if len(rarity_data) == 0:
+            report.error_message = "No data found"
+    except Exception as e:
+        logger.error("Silph Road spawn tier fetch failed: %s", e)
+        report = DataSourceReport(
+            source_name="Silph Road Spawn Tier",
+            pokemon_count=0,
+            success=False,
+            error_message=str(e),
+        )
+    return rarity_data, report

--- a/tests/test_silph_road.py
+++ b/tests/test_silph_road.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pogorarity.sources import silph_road
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_silph_road_mapping(monkeypatch):
+    sample_data = [{"name": "Bulbasaur", "tier": 5}]
+    monkeypatch.setattr(
+        silph_road,
+        "safe_request",
+        lambda url, session=None, metrics=None: DummyResponse(sample_data),
+    )
+    data, report = silph_road.scrape_spawn_tiers()
+    assert report.success
+    assert data["Bulbasaur"] == pytest.approx(
+        silph_road.SILPH_ROAD_TIER_MAPPING[5]
+    )


### PR DESCRIPTION
## Summary
- implement Silph Road spawn tier scraper with configurable tier-to-score mapping
- include Silph Road data in aggregation weights and sources
- document potential regional bias and add coverage tests

## Testing
- `pytest`
- `npx -y markdownlint-cli README.md AGENTS.md` (fails: line-length warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c08282fbb08328b49d192b1c379a65