### PR TITLE
Adjust low-score trading advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ scores are combined using a weighted average:
 The resulting `Average_Rarity_Score` feeds two threshold sets:
 
 - Rarity bands: `<2` Very Rare, `2–4` Rare, `4–7` Uncommon, `≥7` Common.
-- Trading recommendations: score `<4` → "Should Always Trade", `4–7` →
+- Trading recommendations: score `<4` → "Keep or Trade Sparingly", `4–7` →
   "Depends on Circumstances", `≥7` → "Safe to Transfer". Legendary,
   event-only, and evolution-only species override these thresholds with
   conservative recommendations.

--- a/pogorarity/aggregator.py
+++ b/pogorarity/aggregator.py
@@ -107,7 +107,7 @@ def get_trading_recommendation(score: float, spawn_type: str) -> str:
     Pokémon.  The same numeric ranges are used by :func:`app.rarity_band` to
     display rarity bands.  The ranges are:
 
-    - ``score < 4``  -> "Should Always Trade"
+    - ``score < 4``  -> "Keep or Trade Sparingly"
     - ``4 <= score < 7`` -> "Depends on Circumstances"
     - ``score >= 7`` -> "Safe to Transfer"
 
@@ -124,7 +124,7 @@ def get_trading_recommendation(score: float, spawn_type: str) -> str:
         return "Safe to Transfer"
     if score >= 4:
         return "Depends on Circumstances"
-    return "Should Always Trade"
+    return "Keep or Trade Sparingly"
 
 
 def infer_missing_rarity(pokemon_name: str, pokemon_number: int, spawn_type: str) -> float:

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -8,7 +8,7 @@ from pogorarity import get_trading_recommendation, categorize_pokemon_spawn_type
         (5.0, "legendary", "Never Transfer (Legendary)"),
         (5.0, "event-only", "Never Transfer (Event Only)"),
         (5.0, "evolution-only", "Evaluate for Evolution"),
-        (3.99, "wild", "Should Always Trade"),
+        (3.99, "wild", "Keep or Trade Sparingly"),
         (4.0, "wild", "Depends on Circumstances"),
         (6.99, "wild", "Depends on Circumstances"),
         (7.0, "wild", "Safe to Transfer"),


### PR DESCRIPTION
## Summary
- clarify trading recommendation for very rare Pokémon: "Keep or Trade Sparingly"
- align tests with new recommendation label
- document updated recommendation ranges in README

## Testing
- `npx markdownlint-cli README.md AGENTS.md` *(fails: MD013 line-length)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0905db2208328af9e826cdcf86ca9