### PR TITLE
feat: allow configurable source weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ scores are combined using a weighted average:
 - PokeAPI Capture Rate – weight 2.0
 - Silph Road Spawn Tier – weight 0.5
 
+Weights can be customised by passing a JSON file to the CLI with
+`--weights-file`.
+
 The resulting `Average_Rarity_Score` feeds two threshold sets:
 
 - Rarity bands: `<2` Very Rare, `2–4` Rare, `4–7` Uncommon, `≥7` Common.
@@ -91,15 +94,22 @@ pokemon-rarity --limit 5 --dry-run
 # quick one-minute demo
 pokemon-rarity --limit 1 --dry-run
 
+# customise source weighting
+pokemon-rarity --weights-file weights.example.json --dry-run
+
 # launch the Streamlit interface on http://localhost:8501
 streamlit run app.py
 ```
 
 ## Configuration
 
-| Name | Type | Default | Required | Description |
+| Flag | Type | Default | Required | Description |
 |---|---|---|---|---|
-| N/A | – | – | – | Configuration is handled via CLI flags (`--limit`, `--dry-run`, `--output-dir`). |
+| `--limit` | int | – | No | Limit number of Pokémon scraped for testing |
+| `--dry-run` | flag | false | No | Run the scraper without writing CSV output |
+| `--output-dir` | str | – | No | Directory to save the CSV output file |
+| `--weights-file` | str | – | No | JSON file mapping source names to weight multipliers |
+| `--validate-only` | flag | false | No | Validate data without writing CSV output |
 
 ## Commands
 

--- a/pogorarity/cli.py
+++ b/pogorarity/cli.py
@@ -37,6 +37,7 @@ def _run(
     dry_run: bool = False,
     output_dir: Optional[str] = None,
     validate_only: bool = False,
+    weights_file: Optional[str] = None,
 ) -> None:
     run_id = uuid.uuid4().hex
     _log_run(
@@ -66,7 +67,10 @@ def _run(
 
     try:
         metrics = {"requests": 0, "errors": 0, "latencies": []}
-        pokemon_data, reports = aggregate_data(limit=limit, metrics=metrics)
+        weight_path = Path(weights_file) if weights_file else None
+        pokemon_data, reports = aggregate_data(
+            limit=limit, metrics=metrics, weights_path=weight_path
+        )
         report_data_source_quality(reports)
         rows = len(pokemon_data)
 
@@ -124,12 +128,19 @@ def main(argv: Optional[list[str]] = None) -> None:  # pragma: no cover - thin w
     parser.add_argument(
         "--validate-only", action="store_true", help="Validate data without writing CSV output"
     )
+    parser.add_argument(
+        "--weights-file",
+        type=str,
+        default=None,
+        help="Path to JSON file mapping source names to weight multipliers",
+    )
     args = parser.parse_args(argv)
     _run(
         limit=args.limit,
         dry_run=args.dry_run,
         output_dir=args.output_dir,
         validate_only=args.validate_only,
+        weights_file=args.weights_file,
     )
 
 

--- a/weights.example.json
+++ b/weights.example.json
@@ -1,0 +1,9 @@
+{
+    "Structured Spawn Data": 1.0,
+    "Enhanced Curated Data": 1.0,
+    "PokemonDB Catch Rate": 2.0,
+    "PokeAPI Capture Rate": 2.0,
+    "Silph Road Spawn Tier": 0.5,
+    "Game Master Spawn Weight": 1.0,
+    "Game Master Capture Rate": 2.0
+}


### PR DESCRIPTION
## Summary
- allow `aggregate_data` to load source weighting from a JSON file
- add CLI flag `--weights-file` to specify custom source weights
- document weighting configuration and provide example file

## Testing
- `pytest`
- `npx --yes markdownlint-cli README.md AGENTS.md --disable MD013`

------
https://chatgpt.com/codex/tasks/task_e_68c0929946e88328a127548adbff00b7