### PR TITLE
Centralize rarity thresholds for scoring and trading recommendations

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import streamlit as st
 
 from pogorarity.health import check_cache
 from pogorarity.aggregator import SOURCE_WEIGHTS
+from pogorarity.thresholds import SCORE_BANDS
 
 DATA_FILE = Path(__file__).with_name("pokemon_rarity_analysis_enhanced.csv")
 RUN_LOG_FILE = Path(__file__).resolve().parent / "pogorarity" / "run_log.jsonl"
@@ -41,18 +42,10 @@ def generation_from_number(num: int) -> int:
 def rarity_band(score: float) -> str:
     """Map a numeric rarity score to a human-friendly rarity band.
 
-    The underlying data uses higher scores to indicate more common
-    Pokémon. Previously this function treated lower scores as more
-    common, which inverted the rarity bands (e.g. ubiquitous Pokémon
-    like Caterpie were marked "Very Rare"). The thresholds below now
-    reflect the correct ordering where larger scores correspond to more
-    common Pokémon.  The score ranges shared with
-    :func:`pogorarity.aggregator.get_trading_recommendation` are:
-
-    - ``score < 2`` -> "Very Rare"
-    - ``2 <= score < 4`` -> "Rare"
-    - ``4 <= score < 7`` -> "Uncommon"
-    - ``score >= 7`` -> "Common"
+    Higher scores indicate more common Pokémon.  The score bands and
+    thresholds shared with
+    :func:`pogorarity.aggregator.get_trading_recommendation` are defined in
+    :mod:`pogorarity.thresholds`.
 
     Parameters
     ----------
@@ -66,13 +59,11 @@ def rarity_band(score: float) -> str:
         One of "Very Rare", "Rare", "Uncommon", or "Common".
     """
 
-    if score >= 7:
-        return "Common"
-    if score >= 4:
-        return "Uncommon"
-    if score >= 2:
-        return "Rare"
-    return "Very Rare"
+    for threshold, label in SCORE_BANDS:
+        if score >= threshold:
+            return label
+    # Fallback, though SCORE_BANDS should cover all scores
+    return SCORE_BANDS[-1][1]
 
 
 @st.cache_data

--- a/pogorarity/aggregator.py
+++ b/pogorarity/aggregator.py
@@ -12,6 +12,7 @@ from .sources import (
     silph_road,
     game_master,
 )
+from .thresholds import COMMON, UNCOMMON
 
 logger = logging.getLogger(__name__)
 
@@ -87,11 +88,8 @@ def get_trading_recommendation(score: float, spawn_type: str) -> str:
 
     Scores are on a 0--10 scale where higher numbers represent more common
     Pokémon.  The same numeric ranges are used by :func:`app.rarity_band` to
-    display rarity bands.  The ranges are:
-
-    - ``score < 4``  -> "Keep or Trade Sparingly"
-    - ``4 <= score < 7`` -> "Depends on Circumstances"
-    - ``score >= 7`` -> "Safe to Transfer"
+    display rarity bands.  Thresholds are defined in
+    :mod:`pogorarity.thresholds`.
 
     Special spawn types take precedence over the numeric score.
     """
@@ -102,9 +100,9 @@ def get_trading_recommendation(score: float, spawn_type: str) -> str:
         return "Never Transfer (Event Only)"
     if spawn_type == "evolution-only":
         return "Evaluate for Evolution"
-    if score >= 7:
+    if score >= COMMON:
         return "Safe to Transfer"
-    if score >= 4:
+    if score >= UNCOMMON:
         return "Depends on Circumstances"
     return "Keep or Trade Sparingly"
 

--- a/pogorarity/thresholds.py
+++ b/pogorarity/thresholds.py
@@ -1,0 +1,16 @@
+"""Shared constants defining rarity score bands."""
+
+from typing import List, Tuple
+
+# Numeric thresholds for rarity bands. Higher scores mean more common Pokémon.
+COMMON = 7.0
+UNCOMMON = 4.0
+RARE = 2.0
+
+# Ordered list of (minimum_score, band_name) pairs used for categorizing scores.
+SCORE_BANDS: List[Tuple[float, str]] = [
+    (COMMON, "Common"),
+    (UNCOMMON, "Uncommon"),
+    (RARE, "Rare"),
+    (float("-inf"), "Very Rare"),
+]

--- a/tests/test_rarity_band.py
+++ b/tests/test_rarity_band.py
@@ -1,16 +1,17 @@
 from app import rarity_band
+from pogorarity.thresholds import COMMON, UNCOMMON, RARE
 
 
 def test_rarity_band_ordering():
     """Higher scores should correspond to more common bands."""
-    assert rarity_band(1.0) == "Very Rare"
-    assert rarity_band(3.0) == "Rare"
-    assert rarity_band(5.0) == "Uncommon"
-    assert rarity_band(8.0) == "Common"
+    assert rarity_band(RARE - 1) == "Very Rare"
+    assert rarity_band((RARE + UNCOMMON) / 2) == "Rare"
+    assert rarity_band((UNCOMMON + COMMON) / 2) == "Uncommon"
+    assert rarity_band(COMMON + 1) == "Common"
 
 
 def test_rarity_band_boundaries():
     """Boundary scores should fall into the correct bands."""
-    assert rarity_band(2.0) == "Rare"
-    assert rarity_band(4.0) == "Uncommon"
-    assert rarity_band(7.0) == "Common"
+    assert rarity_band(RARE) == "Rare"
+    assert rarity_band(UNCOMMON) == "Uncommon"
+    assert rarity_band(COMMON) == "Common"

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from pogorarity import get_trading_recommendation, categorize_pokemon_spawn_type
+from pogorarity.thresholds import COMMON, UNCOMMON
 
 
 @pytest.mark.parametrize(
@@ -9,10 +10,10 @@ from pogorarity import get_trading_recommendation, categorize_pokemon_spawn_type
         (5.0, "legendary", "Never Transfer (Legendary)"),
         (5.0, "event-only", "Never Transfer (Event Only)"),
         (5.0, "evolution-only", "Evaluate for Evolution"),
-        (3.99, "wild", "Keep or Trade Sparingly"),
-        (4.0, "wild", "Depends on Circumstances"),
-        (6.99, "wild", "Depends on Circumstances"),
-        (7.0, "wild", "Safe to Transfer"),
+        (UNCOMMON - 0.01, "wild", "Keep or Trade Sparingly"),
+        (UNCOMMON, "wild", "Depends on Circumstances"),
+        (COMMON - 0.01, "wild", "Depends on Circumstances"),
+        (COMMON, "wild", "Safe to Transfer"),
     ],
 )
 def test_get_trading_recommendation(score, spawn_type, expected):


### PR DESCRIPTION
## Summary
- add `pogorarity.thresholds` with shared score band constants
- use centralized thresholds in `get_trading_recommendation` and app `rarity_band`
- update tests to reference the shared thresholds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0949770a08328a5aaf1a93e42a827