### PR TITLE
Avoid re-fetching deps when building project wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.lock pyproject.toml ./
 RUN pip install --upgrade pip \
     && pip wheel --wheel-dir /wheels -r requirements.lock
 COPY . .
-RUN pip wheel --wheel-dir /wheels .
+RUN pip wheel --wheel-dir /wheels --no-deps .
 
 FROM python:3.12-slim
 WORKDIR /app


### PR DESCRIPTION
## Summary
- build project wheel in Dockerfile with `--no-deps` so pip doesn't download dependencies again

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1a5a8a89c832892cdb04c5b2f1281