### PR TITLE
chore: add lockfile target and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - run: |
+          pip install pip-tools
+          pip-compile --extra=dev --output-file=requirements.lock pyproject.toml
+          git diff --exit-code requirements.lock
       - run: pip install -r requirements.lock
       - run: pip install -e .[dev]
       - run: pytest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test build run
+.PHONY: dev test build run lock
 
 dev:
 	pip install -r requirements.lock
@@ -11,4 +11,7 @@ build:
 	docker build -t pokemon-rarity .
 
 run:
-	pokemon-rarity --limit 1 --dry-run
+        pokemon-rarity --limit 1 --dry-run
+
+lock:
+	pip-compile --extra=dev --output-file=requirements.lock pyproject.toml

--- a/README.md
+++ b/README.md
@@ -211,11 +211,21 @@ The above HTTP request returns the Streamlit landing page after running `streaml
 | Streamlit port in use | Another service on 8501 | `streamlit run app.py --server.port 8502` |
 | CLI runs too long | Scraping full Pokédex | Use `--limit` during development |
 
+## Updating dependencies
+
+Add new packages to `pyproject.toml` and regenerate the lockfile:
+
+```bash
+make lock
+```
+
+Commit both `pyproject.toml` and `requirements.lock`. CI will fail if the lockfile is outdated.
+
 ## Contributing
 
 1. Fork and clone the repo.
 2. Install dependencies: `pip install -r requirements.lock && pip install -e .[dev]`.
-3. If you change dependencies, regenerate `requirements.lock` via `pip-compile pyproject.toml --output-file=requirements.lock`.
+3. If you change dependencies, run `make lock` to update `requirements.lock`.
 4. Create a feature branch from `main`.
 5. Run tests and lint before committing.
 6. Submit a pull request and mention maintainers.


### PR DESCRIPTION
## Summary
- add `make lock` target to regenerate requirements.lock
- document how to update dependencies
- ensure lockfile freshness in CI

## Testing
- `pytest`
- `npx markdownlint-cli README.md AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_68c1a79a944c83289ec37a8b2aaed3fb