### PR TITLE
Improve Streamlit UI and config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ configurable ``common`` and ``uncommon`` thresholds:
 
 Threshold values live under the ``thresholds`` key in ``config.json`` and are
 surfaced in the Streamlit sidebar.
+The ``generation_ranges`` list can also be adjusted there to map Pokédex
+numbers to game generations.
 
 ## Quickstart
 

--- a/config.example.json
+++ b/config.example.json
@@ -13,5 +13,16 @@
     "Game Master Spawn Weight": 1.0,
     "Game Master Capture Rate": 2.0
   },
-  "spawn_types_path": "data/spawn_types.json"
+  "spawn_types_path": "data/spawn_types.json",
+  "generation_ranges": [
+    [1, 151, 1],
+    [152, 251, 2],
+    [252, 386, 3],
+    [387, 493, 4],
+    [494, 649, 5],
+    [650, 721, 6],
+    [722, 809, 7],
+    [810, 905, 8],
+    [906, 1010, 9]
+  ]
 }

--- a/config.json
+++ b/config.json
@@ -13,5 +13,16 @@
     "Game Master Spawn Weight": 1.0,
     "Game Master Capture Rate": 2.0
   },
-  "spawn_types_path": "data/spawn_types.json"
+  "spawn_types_path": "data/spawn_types.json",
+  "generation_ranges": [
+    [1, 151, 1],
+    [152, 251, 2],
+    [252, 386, 3],
+    [387, 493, 4],
+    [494, 649, 5],
+    [650, 721, 6],
+    [722, 809, 7],
+    [810, 905, 8],
+    [906, 1010, 9]
+  ]
 }


### PR DESCRIPTION
## Summary
- Load generation ranges from config and apply Streamlit page config
- Consolidate sidebar filters into a form with presets, reset, and CSV export
- Switch to boolean mask filtering for better performance

## Testing
- `pytest`
- `npx --yes markdownlint-cli README.md AGENTS.md`

------
https://chatgpt.com/codex/tasks/task_e_68c1b88170dc8328a1901c31a467282e