### PR TITLE
docs: add release workflow and changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,4 +110,17 @@ Output: `/workspace/pokemon_rarity_analysis_enhanced.csv`
 - **Dashboards**: TODO add metrics dashboard.
 - **Incidents**: capture logs, revert to last known good commit, notify maintainers.
 
+## Release Workflow
+
+- Follow [Semantic Versioning](https://semver.org/) in the form `MAJOR.MINOR.PATCH`.
+- Bump versions in:
+  - `pyproject.toml` (`[project] version`)
+  - `CHANGELOG.md` (add a dated entry under the new version)
+- Release steps:
+  1. Ensure `main` is green and tests pass.
+  2. Update the version and changelog files above.
+  3. Commit with message `chore: release vX.Y.Z`.
+  4. Tag the commit `vX.Y.Z` and push commits and tags.
+  5. Publish a GitHub release referencing the tag.
+
 Refer to [README.md](README.md) for project overview and manual commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-09-10
+
+### Added
+
+- Initial release.


### PR DESCRIPTION
## Summary
- document semantic-versioned release workflow in AGENTS
- add Keep a Changelog compliant CHANGELOG with initial release entry

## Testing
- `markdownlint AGENTS.md CHANGELOG.md`
- `pytest`
- `pokemon-rarity --limit 1 --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68c1db33846c8328aa87b268d00b4239