### PR TITLE
feat: track caught Pokémon in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pogorarity/__pycache__/
 env/
 env.bak/
 env.old/
+caught_pokemon.json

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ streamlit run app.py
 cp config.example.json config.json  # edit values as desired
 ```
 
+### Progress tracking
+
+The Streamlit UI lets you mark Pokémon as caught from the detail view and
+filter the table by caught status. Progress is stored locally in
+`caught_pokemon.json` alongside `app.py`.
+
 ## Configuration
 
 | Flag | Type | Default | Required | Description |

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -20,3 +20,18 @@ def test_apply_filters_generation_and_rarity():
     assert list(filtered["Name"]) == ["Bulbasaur"]
     filtered = apply_filters(df, rarity="Common")
     assert list(filtered["Name"]) == ["Chikorita"]
+
+
+def test_apply_filters_caught_status():
+    df = pd.DataFrame(
+        {
+            "Name": ["Bulbasaur", "Chikorita"],
+            "Generation": [1, 2],
+            "Rarity_Band": ["Rare", "Common"],
+        }
+    )
+    caught = {"Bulbasaur"}
+    filtered = apply_filters(df, caught_set=caught, caught=True)
+    assert list(filtered["Name"]) == ["Bulbasaur"]
+    filtered = apply_filters(df, caught_set=caught, caught=False)
+    assert list(filtered["Name"]) == ["Chikorita"]


### PR DESCRIPTION
## Summary
- allow marking Pokémon as caught and persist to `caught_pokemon.json`
- add sidebar filter and column for caught status
- document progress tracking in README

## Testing
- `pytest`
- `npx -y markdownlint-cli README.md AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_68c3045500ec8328b8ede863101dc4d4