### PR TITLE
chore: release v0.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ Output: `/workspace/pokemon_rarity_analysis_enhanced.csv`
 
 ## Release Workflow
 
+- Every update to application code **must** bump the version and changelog.
 - Follow [Semantic Versioning](https://semver.org/) in the form `MAJOR.MINOR.PATCH`.
 - Bump versions in:
   - `pyproject.toml` (`[project] version`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2025-09-11
+
+### Added
+
+- Track caught Pokémon in the UI.
+- Add Pokémon type and region filters.
 
 ## [0.1.0] - 2025-09-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [


### PR DESCRIPTION
## Summary
- clarify that app changes must bump the version and changelog
- bump project version to 0.1.1 with changelog entry for recent UI features

## Testing
- `pytest`
- `npx -y markdownlint-cli AGENTS.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68c30b309b748328b985ab662ab8fb96