### PR TITLE
Fix caught column selection in Streamlit UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-09-12
+
+### Fixed
+
+- Make "Caught" column selectable in the Streamlit UI.
+
 ## [0.1.1] - 2025-09-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ cp config.example.json config.json  # edit values as desired
 
 ### Progress tracking
 
-The Streamlit UI lets you mark Pokémon as caught from the detail view and
-filter the table by caught status. Progress is stored locally in
-`caught_pokemon.json` alongside `app.py`.
+The Streamlit UI lets you mark Pokémon as caught directly in the results table
+or from the detail view. You can also filter the table by caught status.
+Progress is stored locally in `caught_pokemon.json` alongside `app.py`.
 
 ## Configuration
 

--- a/app.py
+++ b/app.py
@@ -271,8 +271,27 @@ def main() -> None:
         display_cols.append("Weighted_Average_Rarity_Score")
     if "Confidence" in result.columns:
         display_cols.append("Confidence")
-    st.dataframe(result[display_cols], use_container_width=True)
-    csv = result.to_csv(index=False).encode("utf-8")
+    display_df = result[display_cols].copy()
+    edited_df = st.data_editor(
+        display_df,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "Caught": st.column_config.CheckboxColumn(
+                "Caught", help="Mark Pokémon as caught"
+            )
+        },
+        disabled=[col for col in display_cols if col != "Caught"],
+    )
+    if not edited_df["Caught"].equals(display_df["Caught"]):
+        for name, marked in edited_df[["Name", "Caught"]].itertuples(index=False):
+            if marked:
+                caught_set.add(name)
+            else:
+                caught_set.discard(name)
+        save_caught(caught_set)
+        st.session_state.caught_set = caught_set
+    csv = edited_df.to_csv(index=False).encode("utf-8")
     st.download_button(
         label="Download results",
         data=csv,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [


### PR DESCRIPTION
## Summary
- make 'Caught' column in Streamlit table selectable via checkboxes
- document marking Pokémon directly from results table
- bump version to v0.1.2

## Testing
- `pytest`
- `markdownlint README.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68c3124fa4188328abe6e4e1462e1ff4