### PR TITLE
Fix rapid caught selection resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2025-09-11
+
+### Fixed
+
+- Preserve previously selected Pokémon when marking multiple as caught in quick succession.
+
 ## [0.1.3] - 2025-09-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [

--- a/tests/test_caught_editor.py
+++ b/tests/test_caught_editor.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import streamlit as st
+
+import app
+
+
+def test_apply_caught_edits_merges_changes(monkeypatch):
+    st.session_state.clear()
+    st.session_state.caught_set = set()
+
+    saved = {}
+
+    def fake_save(caught: set[str]) -> None:
+        saved["caught"] = set(caught)
+
+    monkeypatch.setattr(app, "save_caught", fake_save)
+
+    df = pd.DataFrame({"Name": ["Bulbasaur", "Chikorita"]})
+
+    app.apply_caught_edits(df, {"edited_rows": {"0": {"Caught": True}}})
+    assert st.session_state.caught_set == {"Bulbasaur"}
+
+    # Simulate a rapid second edit where the frontend only sends the second row
+    app.apply_caught_edits(df, {"edited_rows": {"1": {"Caught": True}}})
+    assert st.session_state.caught_set == {"Bulbasaur", "Chikorita"}
+
+    # Unmark the first Pokémon
+    app.apply_caught_edits(df, {"edited_rows": {"0": {"Caught": False}}})
+    assert st.session_state.caught_set == {"Chikorita"}
+
+    # Ensure save_caught was invoked with the latest state
+    assert saved["caught"] == {"Chikorita"}
+


### PR DESCRIPTION
## Summary
- handle Streamlit data editor updates atomically to prevent losing previous caught selections
- add regression test for rapid caught edits
- bump version to 0.1.4

## Testing
- `markdownlint CHANGELOG.md` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c31ac448088328b62553764282ec38