### PR TITLE
fix: avoid Streamlit reload when marking caught Pokémon rapidly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ pogorarity/__pycache__/
 env/
 env.bak/
 env.old/
-caught_pokemon.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2025-09-11
+
+### Fixed
+
+- Store caught Pokémon progress outside the app directory to prevent selection resets when marking multiple as caught rapidly.
+
 ## [0.1.6] - 2025-09-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ cp config.example.json config.json  # edit values as desired
 
 The Streamlit UI lets you mark Pokémon as caught directly in the results table
 or from the detail view. You can also filter the table by caught status.
-Progress is stored locally in `caught_pokemon.json` alongside `app.py`.
+Progress is stored locally in `~/.pogorarity/caught_pokemon.json`.
 
 ## Configuration
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,8 @@ from pogorarity.helpers import load_favorites, save_favorites
 
 DATA_FILE = Path(__file__).with_name("pokemon_rarity_analysis_enhanced.csv")
 RUN_LOG_FILE = Path(__file__).resolve().parent / "pogorarity" / "run_log.jsonl"
-CAUGHT_FILE = Path(__file__).with_name("caught_pokemon.json")
+CAUGHT_DIR = Path.home() / ".pogorarity"
+CAUGHT_FILE = CAUGHT_DIR / "caught_pokemon.json"
 
 DEFAULT_GENERATION_RANGES = [
     (1, 151, 1),
@@ -146,6 +147,7 @@ def load_caught() -> set[str]:
 
 def save_caught(caught: set[str]) -> None:
     """Persist the caught Pokémon set to disk."""
+    CAUGHT_DIR.mkdir(parents=True, exist_ok=True)
     CAUGHT_FILE.write_text(
         json.dumps(sorted(caught)), encoding="utf-8"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.6"
+version = "0.1.7"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [

--- a/tests/test_caught_editor.py
+++ b/tests/test_caught_editor.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pandas as pd
 import streamlit as st
 
@@ -30,4 +32,9 @@ def test_apply_caught_edits_merges_changes(monkeypatch):
 
     # Ensure save_caught was invoked with the latest state
     assert saved["caught"] == {"Chikorita"}
+
+
+def test_caught_file_path():
+    expected = Path.home() / ".pogorarity" / "caught_pokemon.json"
+    assert app.CAUGHT_FILE == expected
 


### PR DESCRIPTION
## Summary
- store `caught_pokemon.json` under `~/.pogorarity` so saving progress no longer triggers Streamlit reloads
- document new storage location and cover with regression test
- release v0.1.7

## Testing
- `npx markdownlint-cli README.md CHANGELOG.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c324e7c0e88328825b428d95615cce