### PR TITLE
fix: guard mock store with versioned lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2025-09-11
+
+### Fixed
+
+- Prevent stale writes in mock store by guarding updates with a versioned lock.
+
 ## [0.1.11] - 2025-09-11
 
 ### Added

--- a/app/backend/mock_store.py
+++ b/app/backend/mock_store.py
@@ -8,6 +8,7 @@ from app.diag.tracer import trace
 
 _store_ids: Set[int] = set()
 _store_ver: int = 0
+_store_lock = threading.Lock()
 
 
 def reset() -> None:
@@ -24,8 +25,10 @@ def persist(ids: Iterable[int], ver: int, delay: bool = True) -> threading.Threa
         if delay:
             maybe_sleep()
         global _store_ids, _store_ver
-        _store_ids = set(ids)
-        _store_ver = ver
+        with _store_lock:
+            if ver > _store_ver:
+                _store_ids = set(ids)
+                _store_ver = ver
         trace("persist_ok", ver=ver, size=len(ids))
 
     t = threading.Thread(target=_commit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.11"
+version = "0.1.12"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [


### PR DESCRIPTION
## Summary
- safeguard mock store writes by acquiring a lock and ignoring stale versions
- bump version to v0.1.12

## Testing
- `pytest tests/test_stale_write_order.py::test_stale_write_order`
- `python tests/rapid_toggle_e2e.py`


------
https://chatgpt.com/codex/tasks/task_e_68c35be86bd4832899429593389083fe