### PR TITLE
feat: add sql store locking and stale write test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13] - 2025-09-12
+
+### Fixed
+
+- Guard real store writes with a versioned lock to avoid stale commits.
+
 ## [0.1.12] - 2025-09-11
 
 ### Fixed

--- a/app/backend/sql_store.py
+++ b/app/backend/sql_store.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Iterable, Set, Tuple
+
+from app.diag.latency import maybe_sleep
+from app.diag.tracer import trace
+
+_LOCK = threading.Lock()
+
+
+def _ensure_conn(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    with conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS meta (ver INTEGER)")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS caught (id INTEGER PRIMARY KEY)")
+        cur = conn.execute("SELECT COUNT(*) FROM meta")
+        if cur.fetchone()[0] == 0:
+            conn.execute("INSERT INTO meta (ver) VALUES (0)")
+    return conn
+
+
+def reset(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+
+
+def persist(ids: Iterable[int], ver: int, path: Path, delay: bool = True) -> threading.Thread:
+    ids = set(ids)
+
+    def _commit() -> None:
+        trace("persist_start", ver=ver, size=len(ids))
+        if delay:
+            maybe_sleep()
+        conn = _ensure_conn(path)
+        try:
+            with _LOCK:
+                cur_ver = conn.execute("SELECT ver FROM meta").fetchone()[0]
+                if ver > cur_ver:
+                    conn.execute("DELETE FROM caught")
+                    conn.executemany(
+                        "INSERT INTO caught(id) VALUES (?)",
+                        [(i,) for i in ids],
+                    )
+                    conn.execute("UPDATE meta SET ver=?", (ver,))
+                    conn.commit()
+        finally:
+            conn.close()
+        trace("persist_ok", ver=ver, size=len(ids))
+
+    t = threading.Thread(target=_commit)
+    t.start()
+    return t
+
+
+def load(path: Path) -> Tuple[Set[int], int]:
+    conn = _ensure_conn(path)
+    try:
+        rows = conn.execute("SELECT id FROM caught").fetchall()
+        ids = {row[0] for row in rows}
+        ver = conn.execute("SELECT ver FROM meta").fetchone()[0]
+        trace("load", ver=ver, size=len(ids))
+        return ids, ver
+    finally:
+        conn.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.12"
+version = "0.1.13"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [

--- a/tests/test_stale_write_order_sql.py
+++ b/tests/test_stale_write_order_sql.py
@@ -1,0 +1,12 @@
+from app.backend import sql_store
+
+
+def test_stale_write_order_sql(tmp_path):
+    db = tmp_path / "caught.db"
+    sql_store.reset(db)
+    t1 = sql_store.persist({1}, 1, db, delay=True)
+    t2 = sql_store.persist({1, 2}, 2, db, delay=False)
+    t1.join()
+    t2.join()
+    ids, ver = sql_store.load(db)
+    assert ver == 2, "older write overwrote newer state"


### PR DESCRIPTION
## Summary
- add SQLite-backed store with versioned lock
- test real store prevents stale writes
- bump version to 0.1.13

## Testing
- `pytest tests/test_stale_write_order.py tests/test_stale_write_order_sql.py`
- `npx markdownlint-cli CHANGELOG.md` *(fails: package installation prompt)*
- `pytest` *(fails: ImportError: cannot import name 'rarity_band' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c362e38c6c832883d301282f2863ef