### PR TITLE
feat: log selection toggles as events with compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15] - 2025-09-13
+
+### Added
+
+- Persist caught toggles as append-only events with log compaction.
+- Test interleaved add/remove event sequences.
+
 ## [0.1.14] - 2025-09-12
 
 ### Fixed

--- a/app/backend/event_store.py
+++ b/app/backend/event_store.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Set, Tuple
+
+DEFAULT_LOG_PATH = Path.home() / ".pogorarity" / "caught.log"
+COMPACT_EVERY = 100
+
+
+def append_event(
+    pid: int,
+    op: str,
+    path: Path = DEFAULT_LOG_PATH,
+    *,
+    compact_every: int = COMPACT_EVERY,
+    timestamp: float | None = None,
+) -> None:
+    """Append a toggle event to ``path``.
+
+    Parameters
+    ----------
+    pid:
+        Pokémon ID to toggle.
+    op:
+        Either ``"add"`` or ``"remove"``.
+    path:
+        Log file to append to.
+    compact_every:
+        Compact the log after this many events.
+    timestamp:
+        Optional event timestamp; defaults to ``time.time()``.
+    """
+
+    if timestamp is None:
+        timestamp = time.time()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"op": op, "id": pid, "ts": timestamp}) + "\n")
+    try:
+        if compact_every and sum(1 for _ in path.open("r", encoding="utf-8")) > compact_every:
+            compact(path)
+    except FileNotFoundError:
+        pass
+
+
+def append_toggle(
+    pid: int,
+    checked: bool,
+    path: Path = DEFAULT_LOG_PATH,
+    *,
+    compact_every: int = COMPACT_EVERY,
+) -> None:
+    """Append an add/remove event based on ``checked``."""
+
+    op = "add" if checked else "remove"
+    append_event(pid, op, path=path, compact_every=compact_every)
+
+
+def load(path: Path = DEFAULT_LOG_PATH) -> Tuple[Set[int], int]:
+    """Fold all events in ``path`` and return the resulting set and version."""
+
+    ids: Set[int] = set()
+    count = 0
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                count += 1
+                evt = json.loads(line)
+                if evt.get("op") == "add":
+                    ids.add(int(evt["id"]))
+                elif evt.get("op") == "remove":
+                    ids.discard(int(evt["id"]))
+    except FileNotFoundError:
+        pass
+    return ids, count
+
+
+def compact(path: Path = DEFAULT_LOG_PATH) -> None:
+    """Rewrite ``path`` with a minimal set of add events."""
+
+    ids, _ = load(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ts = time.time()
+    with path.open("w", encoding="utf-8") as f:
+        for pid in sorted(ids):
+            f.write(json.dumps({"op": "add", "id": pid, "ts": ts}) + "\n")

--- a/pages/10_debug_selection.py
+++ b/pages/10_debug_selection.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from app.backend.mock_store import load, persist
+from app.backend.event_store import append_toggle, load
 from app.diag.tracer import trace
 from app.state.selection import ensure_session_state, toggle_and_bump
 
@@ -19,8 +19,7 @@ def on_change(pid: int):
     checked = st.session_state[f"caught_{pid}"]
     ver, ids = toggle_and_bump(st, pid, checked)
     trace("toggle", pid=pid, checked=checked, ver=ver, size=len(ids))
-    if simulate_latency:
-        persist(ids, ver)
+    append_toggle(pid, checked)
 
 
 st.title("Debug: Selection State")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pogorarity"
-version = "0.1.14"
+version = "0.1.15"
 requires-python = ">=3.10"
 description = "A tool to determine the rarity of Pokemon in Pokemon Go."
 dependencies = [

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,0 +1,28 @@
+from app.backend import event_store
+
+
+def test_interleaved_events(tmp_path):
+    log = tmp_path / "events.log"
+    # sequence of add/remove events
+    event_store.append_event(1, "add", path=log)
+    event_store.append_event(2, "add", path=log)
+    event_store.append_event(1, "remove", path=log)
+    event_store.append_event(3, "add", path=log)
+    event_store.append_event(2, "remove", path=log)
+    event_store.append_event(1, "add", path=log)
+    ids, ver = event_store.load(log)
+    assert ids == {1, 3}
+    # version equals number of events processed
+    assert ver == 6
+
+
+def test_compaction(tmp_path):
+    log = tmp_path / "events.log"
+    for _ in range(6):
+        event_store.append_event(1, "add", path=log, compact_every=5)
+        event_store.append_event(1, "remove", path=log, compact_every=5)
+    ids, _ = event_store.load(log)
+    assert ids == set()
+    # after compaction log should be empty
+    assert log.exists()
+    assert log.read_text() == ""


### PR DESCRIPTION
## Summary
- track each caught toggle as add/remove events with periodic log compaction
- surface event store in debug page and verify interleaved add/remove behavior
- bump version to 0.1.15

## Testing
- `pytest`
- `markdownlint CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68c4cfa020288328961275bcce12aa59