### PR TITLE
feat: persist caught set in sqlite

### DIFF
--- a/tests/test_stale_write_order_save_caught.py
+++ b/tests/test_stale_write_order_save_caught.py
@@ -1,30 +1,34 @@
-import json
 import threading
 import time
-from pathlib import Path
 
 import streamlit as st
 
 import app
+from app.backend import sql_store
 
 
 def test_stale_write_order_save_caught(tmp_path, monkeypatch):
     st.session_state.clear()
+    db = tmp_path / "caught.db"
     monkeypatch.setattr(app, "CAUGHT_DIR", tmp_path)
     monkeypatch.setattr(app.app_module, "CAUGHT_DIR", tmp_path)
-    monkeypatch.setattr(app, "CAUGHT_FILE", tmp_path / "caught.json")
-    monkeypatch.setattr(app.app_module, "CAUGHT_FILE", tmp_path / "caught.json")
+    monkeypatch.setattr(app, "CAUGHT_DB", db)
+    monkeypatch.setattr(app.app_module, "CAUGHT_DB", db)
+    sql_store.reset(db)
     st.session_state.caught_set = set()
     st.session_state.selection_version = 0
     st.session_state.caught_saved_version = 0
 
-    original_write = Path.write_text
+    original_persist = app.sql_store.persist
+    call = {"count": 0}
 
-    def slow_write(self, *args, **kwargs):
-        time.sleep(0.1)
-        return original_write(self, *args, **kwargs)
+    def slow_persist(ids, ver, path, delay=False):
+        if call["count"] == 0:
+            time.sleep(0.1)
+        call["count"] += 1
+        return original_persist(ids, ver, path, delay=False)
 
-    monkeypatch.setattr(Path, "write_text", slow_write)
+    monkeypatch.setattr(app.sql_store, "persist", slow_persist)
 
     def persist(caught, version):
         def run():
@@ -41,6 +45,6 @@ def test_stale_write_order_save_caught(tmp_path, monkeypatch):
     t1.join()
     t2.join()
 
-    data = json.loads(app.CAUGHT_FILE.read_text())
-    assert data == ["Bulbasaur", "Chikorita"]
+    ids, ver = sql_store.load(db)
+    assert ids == {"Bulbasaur", "Chikorita"}
     assert st.session_state.caught_saved_version == 2


### PR DESCRIPTION
## Summary
- switch caught persistence to SQLite and initialize DB on startup
- save/load caught set via sql_store
- adjust tests to use new SQL store

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d2854b0c8328bf4c89f6bf2b89db